### PR TITLE
Github workflow to push docker images to DockerHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  RAILS_ENV: production
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Set DOCKER_IMAGE Environment Variable
+        run:  echo "DOCKER_IMAGE=dfedigital/eyfsreform:${{ github.sha }}" >> $GITHUB_ENV
+
+      - name: Build and push docker image to DockerHub
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ env.DOCKER_IMAGE }}
+          build-args: COMMIT_SHA=${{ github.sha }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,6 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
-      elasticsearch:
-        image: elasticsearch:6.8.3
-        ports:
-          - 9200:9200
-        options: -e="discovery.type=single-node" --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ You can manually set a password for the user `boilerplate_user` by following the
 See [this guide](https://design-system.service.gov.uk/get-started/) for
 advice about how to layout html
 
+## CI/CD
+
+When a branch is merged into `main`
+
+- a docker image is built and pushed to [DockerHub](https://hub.docker.com/repository/docker/dfedigital/eyfsreform)
+
 
 # The following is from the template repository GOV.UK Rails Boilerplate
 


### PR DESCRIPTION
### Context

Github workflow to build and push docker image to DockerHub

### Changes proposed in this pull request

Adds a new build step that
- logs into DockerHub
- builds the docker image
- pushes the built image to DockerHub

Images will be pushed to the following repository
https://hub.docker.com/repository/docker/dfedigital/eyfsreform

### Guidance to review

Have a look at the workflow file and the github workflow for this PR
