### PR TITLE
Triggering github build workflow when a PR is merged to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - master
+      - main
 
 env:
   RAILS_ENV: production


### PR DESCRIPTION
### Context

The build workflow was not being triggered because it was targeted at the `master` branch

### Changes proposed in this pull request

Given this repo works off the `main` branch, this PR triggers the build workflow on a PR merge to the `main` branch

### Guidance to review

