### PR TITLE
Constrained to terraform version 0.14.0

### DIFF
--- a/terraform/app/versions.tf
+++ b/terraform/app/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.14.5"
+  required_version = ">= 0.14.0"
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"


### PR DESCRIPTION
### Context

Was getting errors when running Terraform commands from github workflows because it required version 0.14.0 support

### Changes proposed in this pull request

Setting Terraform version to 0.14.0

### Guidance to review

