### PR TITLE
Order the mobile menu items and merge mistake I made

### DIFF
--- a/app/views/layouts/_mobile_menu.html.erb
+++ b/app/views/layouts/_mobile_menu.html.erb
@@ -1,12 +1,12 @@
 <nav class="app-subnav--mobile app-mobile-nav js-app-mobile-nav">
-  <% ContentPage.top_level.each do |top_level_page| %>
+  <% ContentPage.top_level.order_by_position.each do |top_level_page| %>
     <div class="learning-section-mobile-nav app-mobile-nav-subnav-toggler">
       <%= link_to(raw('<h4 class="app-subnav__theme ">' + top_level_page.title + '</h4>'), path_for_this_page(top_level_page), class: "govuk-link app-subnav__link govuk-link--no-visited-state top-level-link") %>
       <ul class="app-mobile-nav__list app-mobile-subnav-section app-mobile-nav__subnav">
         <li class="app-mobile-nav__subnav-item <%= is_current?(top_level_page) ? 'app-mobile-nav__subnav-item--current' : '' %>">
           <%= link_to('Overview', path_for_this_page(top_level_page), class: "govuk-link app-subnav__link govuk-link--no-visited-state") %>
         </li>
-        <% top_level_page.children.each do |child| %>
+        <% top_level_page.children.order_by_position.each do |child| %>
           <li class="app-mobile-nav__subnav-item <%= is_current?(child) ? 'app-mobile-nav__subnav-item--current' : '' %>">
             <%= link_to(child.title, path_for_this_page(child), class: "govuk-link app-subnav__link govuk-link--no-visited-state") %>
           </li>

--- a/app/views/layouts/landing_page_layout.html.erb
+++ b/app/views/layouts/landing_page_layout.html.erb
@@ -271,7 +271,7 @@
           <% ContentPage.top_level.order_by_position.each do |content_page| %>
             <li class="govuk-grid-column-one-half eyfs-card-group__item">
               <div class="eyfs-card eyfs-card--clickable eyfs-card--icon">
-                <div class="nhsuk-card__content">
+                <div class="eyfs-card__content">
                   <a class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold govuk-link--no-visited-state" href="<%= content_url + '/' + content_page.slug %>"><%= content_page.title %></a>
                 </div>
               </div>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -15,9 +15,9 @@ $(document).ready(function() {
   $('#markdown-editor').keyup(function() {
     createPreview('#markdown-editor','#markdown-render');
   });
-  
+
   //----- mobile nav -----//
-  
+
   //show mobile nav when clicking hamburger
   $( ".govuk-js-header-toggle" ).click(function() {
     $( ".app-subnav--mobile" ).toggleClass('app-mobile-nav--active');
@@ -26,7 +26,7 @@ $(document).ready(function() {
   //show subnav links when clicking top level
   $('.learning-section-mobile-nav > a').click(function() {
     $(this).parent().children('ul.app-mobile-subnav-section').toggle();
-  }); 
+  });
 
   //disable top level section click on mobile nav
   $('.learning-section-mobile-nav .top-level-link').click(function(e) {
@@ -38,7 +38,7 @@ $(document).ready(function() {
     copyToClipboard();
   });
 
-  document.querySelectorAll('.nhsuk-card--clickable').forEach((panel) => {
+  document.querySelectorAll('.eyfs-card--clickable').forEach((panel) => {
     // Check if panel has a link within it
     if (panel.querySelector('a') !== null) {
       // Clicks the link within the heading to navigate to desired page
@@ -47,5 +47,5 @@ $(document).ready(function() {
       });
     }
   });
-  
+
 });

--- a/app/webpacker/styles/_cards.scss
+++ b/app/webpacker/styles/_cards.scss
@@ -14,16 +14,16 @@ $card-border-hover-color: #003078;
   width: 100%;
 }
 
-.nhsuk-card__content {
+.eyfs-card__content {
   // @include top-and-bottom();
   @include govuk-responsive-padding(5);
 
   position: relative;
 }
 
-.nhsuk-card__heading,
-.nhsuk-card__metadata,
-.nhsuk-card__description {
+.eyfs-card__heading,
+.eyfs-card__metadata,
+.eyfs-card__description {
   margin-bottom: govuk-spacing(3);
 }
 
@@ -37,8 +37,8 @@ $card-border-hover-color: #003078;
   &:active {
     cursor: pointer;
 
-    .nhsuk-card__heading a,
-    .nhsuk-card__link {
+    .eyfs-card__heading a,
+    .eyfs-card__link {
       color: $govuk-link-hover-colour;
       text-decoration: none;
 


### PR DESCRIPTION
### Context
The automatic merge of my last PR did not take account of css class .nhs-card being renamed to .eyfs-card. And was no test to warn

Also fixes the ordering of the mobile menus

### Changes proposed in this pull request

### Guidance to review
Check that the mobile menus and sub menus are in the same order as the desktop menus

