### PR TITLE
Rake task to destroy user

### DIFF
--- a/.github/workflows/delete_user.yml
+++ b/.github/workflows/delete_user.yml
@@ -1,0 +1,45 @@
+name: Deploy to Pre Prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment
+        required: true
+        default: dev
+      email:
+        description: email address of user to destroy
+        required: true
+        default: ''
+
+jobs:
+  delete_user:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install CF CLI
+        uses: DFE-Digital/github-actions/setup-cf-cli@master
+        with:
+          if: ${{ github.event.inputs.environment == 'dev' }}
+            CF_USERNAME: ${{ secrets.GOVPAAS_USERNAME }}
+            CF_PASSWORD: ${{ secrets.GOVPAAS_PASSWORD }}
+          if: ${{ github.event.inputs.environment == 'test' }}
+            CF_USERNAME: ${{ secrets.GOVPAAS_USERNAME_TEST }}
+            CF_PASSWORD: ${{ secrets.GOVPAAS_PASSWORD_TEST }}
+          if: ${{ github.event.inputs.environment == 'pre-prod' }}
+            CF_USERNAME: ${{ secrets.GOVPAAS_USERNAME_PREPROD }}
+            CF_PASSWORD: ${{ secrets.GOVPAAS_PASSWORD_PREPROD }}
+          if: ${{ github.event.inputs.environment == 'prod' }}
+            CF_USERNAME: ${{ secrets.GOVPAAS_USERNAME_PROD }}
+            CF_PASSWORD: ${{ secrets.GOVPAAS_PASSWORD_PROD }}
+
+          CF_SPACE_NAME: eyfs-${{ github.event.inputs.environment }} # required
+          # Optional inputs
+          CF_CLI_VERSION: v7 # default v7, allowed values: v6 or v7
+          CF_ORG_NAME: dfe # default
+          CF_API_URL:  https://api.london.cloud.service.gov.uk # default
+          INSTALL_CONDUIT: true # default: false
+
+      - name: Run delete user task
+        run: |
+          cf run-task eyfs-${{ github.event.inputs.environment }} --command "cd /app/ && RAILS_ENV=production /usr/local/bin/bundle exec rake sys_admin_tasks:destroy_user['${{ github.event.inputs.email }}']" --name delete-user

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem "canonical-rails"
 
 gem "acts_as_tree"
 
+gem "acts_as_paranoid", "~> 0.7.0"
+
 gem "govspeak"
 gem "htmlentities", "4.3.4"
 # For generating HTML from Markdown

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,9 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    acts_as_paranoid (0.7.0)
+      activerecord (>= 5.2, < 7.0)
+      activesupport (>= 5.2, < 7.0)
     acts_as_tree (2.9.1)
       activerecord (>= 3.0.0)
     addressable (2.7.0)
@@ -367,6 +370,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts_as_paranoid (~> 0.7.0)
   acts_as_tree
   aws-sdk-s3
   bcrypt (~> 3.1.16)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  acts_as_paranoid
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, #:registerable,

--- a/db/migrate/20210224143228_add_deleted_at_to_user.rb
+++ b/db/migrate/20210224143228_add_deleted_at_to_user.rb
@@ -1,0 +1,6 @@
+class AddDeletedAtToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :deleted_at, :datetime
+    add_index :users, :deleted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_12_160639) do
+ActiveRecord::Schema.define(version: 2021_02_24_143228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,8 @@ ActiveRecord::Schema.define(version: 2021_02_12_160639) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.datetime "deleted_at"
+    t.index ["deleted_at"], name: "index_users_on_deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/lib/tasks/sys_admin_tasks.rake
+++ b/lib/tasks/sys_admin_tasks.rake
@@ -1,0 +1,7 @@
+desc "Tasks triggered by sys admins"
+namespace :sys_admin_tasks do
+  desc "destroy user"
+  task :destroy_user, [:email] => :environment do |_, args|
+    User.find_by(email: args.email).destroy!
+  end
+end

--- a/lib/tasks/sys_admin_tasks.rake
+++ b/lib/tasks/sys_admin_tasks.rake
@@ -3,5 +3,7 @@ namespace :sys_admin_tasks do
   desc "destroy user"
   task :destroy_user, [:email] => :environment do |_, args|
     User.find_by(email: args.email).destroy!
+  rescue NoMethodError
+    throw StandardError.new("User not found")
   end
 end

--- a/spec/lib/tasks/sys_admin_tasks_spec.rb
+++ b/spec/lib/tasks/sys_admin_tasks_spec.rb
@@ -25,7 +25,7 @@ describe "sys_admin_tasks" do
 
     context "User not found" do
       it "raises error" do
-        expect { run_destroy_user }.to raise_error(NoMethodError)
+        expect { run_destroy_user }.to raise_error(StandardError)
       end
     end
   end

--- a/spec/lib/tasks/sys_admin_tasks_spec.rb
+++ b/spec/lib/tasks/sys_admin_tasks_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe "sys_admin_tasks" do
+  let(:email) { Faker::Internet.email }
+  let(:run_destroy_user) do
+    Rake::Task["sys_admin_tasks:destroy_user"].invoke(email)
+  end
+
+  before(:each) do
+    Rails.application.load_tasks
+  end
+
+  after(:each) do
+    Rake::Task["sys_admin_tasks:destroy_user"].reenable
+  end
+
+  describe "#destroy_user" do
+    it "reduces user count" do
+      FactoryBot.create(:user, email: email)
+
+      expect { run_destroy_user }.to change { User.count }
+        .from(User.count)
+        .to(User.count - 1)
+    end
+
+    context "User not found" do
+      it "raises error" do
+        expect { run_destroy_user }.to raise_error(NoMethodError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

This PR creates a Rake task that can be run to destroy a user.
The task take an email as an argument.

Added `act_as_paranoid` gem for soft deletions

### Changes proposed in this pull request

### Guidance to review

