### PR TITLE
Added the audited gem, which will quietly save every change made to the PageContent table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,10 +34,10 @@ gem "acts_as_tree"
 
 gem "acts_as_paranoid", "~> 0.7.0"
 
+gem "audited", "~> 4.9"
+
 gem "govspeak"
 gem "htmlentities", "4.3.4"
-# For generating HTML from Markdown
-gem "redcarpet"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.1.0", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    audited (4.10.0)
+      activerecord (>= 4.2, < 6.2)
     aws-eventstream (1.1.0)
     aws-partitions (1.427.0)
     aws-sdk-core (3.112.0)
@@ -242,7 +244,6 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redcarpet (3.5.1)
     regexp_parser (2.0.3)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -370,6 +371,7 @@ PLATFORMS
 DEPENDENCIES
   acts_as_paranoid (~> 0.7.0)
   acts_as_tree
+  audited (~> 4.9)
   aws-sdk-s3
   bcrypt (~> 3.1.16)
   bootsnap (>= 1.1.0)
@@ -388,7 +390,6 @@ DEPENDENCIES
   pry-byebug
   puma (~> 5.1)
   rails (~> 6.1.1)
-  redcarpet
   rspec-rails (~> 4.0.2)
   rubocop-govuk
   scss_lint-govuk

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It allows editors to create a set of nested pages, and to edit the headings,
 overview and content as [Markdown](https://en.wikipedia.org/wiki/Markdown).
 
 These are some examples of the cut down CMS and two resulting pages
-all in UK.GOV style
+all in UK.GOV style;
 
 ![The CMS view](docs/cms-view.png?raw=true "The CMS view"seed)
 ![Example page](docs/public-view-of-a-page.png?raw=true "Example page")

--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -1,5 +1,6 @@
 class ContentPage < ApplicationRecord
   acts_as_tree
+  audited
 
   scope :top_level, -> { where("parent_id IS NULL") }
   scope :order_by_position, -> { order("position ASC") }

--- a/db/migrate/20210303125510_install_audited.rb
+++ b/db/migrate/20210303125510_install_audited.rb
@@ -1,0 +1,30 @@
+class InstallAudited < ActiveRecord::Migration[6.1]
+  def self.up
+    create_table :audits, force: true do |t|
+      t.column :auditable_id, :integer
+      t.column :auditable_type, :string
+      t.column :associated_id, :integer
+      t.column :associated_type, :string
+      t.column :user_id, :integer
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :text
+      t.column :version, :integer, default: 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.timestamps
+    end
+
+    add_index :audits, %i[auditable_type auditable_id version], name: "auditable_index"
+    add_index :audits, %i[associated_type associated_id], name: "associated_index"
+    add_index :audits, %i[user_id user_type], name: "user_index"
+    add_index :audits, :request_uuid
+    add_index :audits, :created_at
+  end
+
+  def self.down
+    drop_table :audits
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_24_143228) do
+ActiveRecord::Schema.define(version: 2021_03_03_125510) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,28 @@ ActiveRecord::Schema.define(version: 2021_02_24_143228) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "audits", force: :cascade do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.text "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
   create_table "content_assets", force: :cascade do |t|


### PR DESCRIPTION
### Context
The audited gem will now watch for changes to PageContent and save changes to the new audited table

We don't need to do anything else until somebody wants to know about the page history

This is not versioning, its an audit trail

### Changes proposed in this pull request
Added audited to PageContent
Added the audited gem

### Guidance to review
Run the new migration
Run the app and edit a page
Look in the database to see who changed what when
This is what the database table looks like on my dev machine after running the seed data
![Screenshot 2021-03-03 at 13 07 43](https://user-images.githubusercontent.com/3352035/109810851-f6202980-7c21-11eb-86e1-3fcfb0c09bb0.png)



