### PR TITLE
Remove seo and subtitle attributes from the ContentPage model

### DIFF
--- a/app/controllers/content_pages_controller.rb
+++ b/app/controllers/content_pages_controller.rb
@@ -60,6 +60,6 @@ private
 
   # Only allow a list of trusted parameters through.
   def content_page_params
-    params.require(:content_page).permit(:title, :markdown, :seo, :subtitle, :parent_id, :position)
+    params.require(:content_page).permit(:title, :markdown, :parent_id, :position)
   end
 end

--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -7,9 +7,7 @@ class ContentPage < ApplicationRecord
   ONLY_ALPHA_NUMERIC_COMMA_HYPHEN_AND_SPACE = /\A[a-zA-Z0-9,.\- ]+\Z/.freeze
   validates :title, format: { with: ONLY_ALPHA_NUMERIC_COMMA_HYPHEN_AND_SPACE, message: "should only contain alphabetic, numeric, comma, fullstop, hyphen and space characters" }
   validates :title, presence: true, uniqueness: true
-  validates :subtitle, presence: true
   validates :markdown, presence: true
-  validates :seo, presence: true
 
   validates :position, presence: true, numericality: { only_integer: true }
   validates :position, uniqueness: { scope: :parent_id }

--- a/app/views/content_pages/_details_for_a_single_page.erb
+++ b/app/views/content_pages/_details_for_a_single_page.erb
@@ -9,9 +9,6 @@
         |<%= link_to 'Preview', '/content/' + page_to_render.slug, target: "_blank" %>
       </span>
     </h3>
-    <p>
-      <%= page_to_render.subtitle %>
-    </p>
   </div>
   <br/>
   <div>

--- a/app/views/content_pages/_form.html.erb
+++ b/app/views/content_pages/_form.html.erb
@@ -25,24 +25,11 @@
               <%= form.text_field :title, :class => 'govuk-input govuk-!-width-three-quarters', :disabled => (@content_page.title && !@content_page.parent_id) %>
             </div>
 
-            <div class="govuk-form-group">
-              <label class="govuk-label" for="subtitle">
-                <%= form.label :subtitle, "Overview" %>
-              </label>
-              <%= form.text_area :subtitle, :rows => 5, :cols => 35, :class => "govuk-textarea"%>
-            </div>
-
             <div class="govuk-form-group gem-c-govspeak">
               <div id="markdown-hint" class="govuk-hint">
                 Content
               </div>
               <%= form.text_area :markdown, :id => 'markdown-editor', :rows => 20, :cols => 35,  :class => "govuk-textarea" %>
-            </div>
-            <div class="govuk-form-group">
-              <label class="govuk-label" for="seo">
-                Search Engine Words
-              </label>
-              <%= form.text_field :seo, :class => 'govuk-input govuk-!-width-three-quarters' %>
             </div>
 
             <div class="govuk-form-group">

--- a/app/views/content_pages/show.html.erb
+++ b/app/views/content_pages/show.html.erb
@@ -6,18 +6,8 @@
 </p>
 
 <p>
-  <strong>Subtitle:</strong>
-  <%= @content_page.subtitle %>
-</p>
-
-<p>
   <strong>Content (Govspeak):</strong>
   <%= @content_page.markdown %>
-</p>
-
-<p>
-  <strong>SEO:</strong>
-  <%= @content_page.seo %>
 </p>
 
 <%= link_to 'Edit', edit_content_page_path(@content_page) %> |

--- a/db/migrate/20210212120340_remove_position_index_from_content_page.rb
+++ b/db/migrate/20210212120340_remove_position_index_from_content_page.rb
@@ -1,9 +1,15 @@
 class RemovePositionIndexFromContentPage < ActiveRecord::Migration[6.1]
   def up
-    remove_index :content_pages, name: "index_content_pages_on_position"
+    remove_column :content_pages, bulk: true do |t|
+      t.string  :seo
+      t.string  :subtitle
+    end
   end
 
   def down
-    add_index :content_pages, :position, unique: true
+    add_column :content_pages, bulk: true do |t|
+      t.string  :seo
+      t.string  :subtitle
+    end
   end
 end

--- a/db/migrate/20210212120340_remove_position_index_from_content_page.rb
+++ b/db/migrate/20210212120340_remove_position_index_from_content_page.rb
@@ -1,15 +1,9 @@
 class RemovePositionIndexFromContentPage < ActiveRecord::Migration[6.1]
   def up
-    remove_column :content_pages, bulk: true do |t|
-      t.string  :seo
-      t.string  :subtitle
-    end
+    remove_index :content_pages, name: "index_content_pages_on_position"
   end
 
   def down
-    add_column :content_pages, bulk: true do |t|
-      t.string  :seo
-      t.string  :subtitle
-    end
+    add_index :content_pages, :position, unique: true
   end
 end

--- a/db/migrate/20210303142112_remove_seo_from_content_pages.rb
+++ b/db/migrate/20210303142112_remove_seo_from_content_pages.rb
@@ -1,0 +1,15 @@
+class RemoveSeoFromContentPages < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :content_pages, bulk: true do |t|
+      t.string  :seo
+      t.string  :subtitle
+    end
+  end
+
+  def down
+    add_column :content_pages, bulk: true do |t|
+      t.string  :seo
+      t.string  :subtitle
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_24_143228) do
+ActiveRecord::Schema.define(version: 2021_03_03_142112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,28 @@ ActiveRecord::Schema.define(version: 2021_02_24_143228) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "audits", force: :cascade do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.text "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
   create_table "content_assets", force: :cascade do |t|

--- a/db/seeds/communication_and_language_seeds.rb
+++ b/db/seeds/communication_and_language_seeds.rb
@@ -27,9 +27,7 @@ MARKDOWN_FOR_COMMUNICATION
 
 communication_and_language = {
   title: "Communication and language",
-  subtitle: "Communication and language",
   markdown: markdown_for_communication_and_language,
-  seo: "Early-Years-Foundation-Stage",
   position: 1,
 }
 communication_and_language_page = ContentPage.new communication_and_language
@@ -116,9 +114,7 @@ Familiar objects to model telling a story create a point of shared understanding
 MARKDOWN_FOR_EXPLORING_LANGUAGE
 exploring_language = {
   title: "Exploring language",
-  subtitle: "Exploring language",
   markdown: markdown_for_exploring_language,
-  seo: "Early-Years-Foundation-Stage",
   position: 2,
   parent_id: communication_and_language_page.id,
 }
@@ -242,9 +238,7 @@ Positive interactions that children have, both adult-child and child-child, enco
 MARKDOWN_FOR_INTERACTIONS
 interactions = {
   title: "Interactions",
-  subtitle: "Interactions",
   markdown: markdown_for_interactions,
-  seo: "Early-Years-Foundation-Stage",
   position: 1,
   parent_id: communication_and_language_page.id,
 }
@@ -261,9 +255,7 @@ This page is still being written
 MARKDOWN_FOR_LISTENING_AND_UNDERSTANDING
 listening_and_understanding = {
   title: "Listening and understanding",
-  subtitle: "This should not appear !",
   markdown: markdown_for_listening_and_understanding,
-  seo: "Early-Years-Foundation-Stage",
   position: 3,
   parent_id: communication_and_language_page.id,
 }

--- a/db/seeds/expressive_arts_and_design_seeds.rb
+++ b/db/seeds/expressive_arts_and_design_seeds.rb
@@ -30,9 +30,7 @@ MARKDOWN_FOR_EXPRESSIVE_ARTS_AND_DESIGN
 
 expressive_arts_and_design = {
   title: "Expressive arts and design",
-  subtitle: "Access resources, activity ideas and advice for teaching expressive arts and design to early years children.",
   markdown: markdown_for_expressive_arts_and_design,
-  seo: "Early-Years-Foundation-Stage",
   position: 7,
 }
 expressive_arts_and_design_page = ContentPage.new expressive_arts_and_design
@@ -48,9 +46,7 @@ This page is still being written.
 MARKDOWN_FOR_IMAGINATION_AND_CREATIVITY
 imagination_and_creativity = {
   title: "Imagination and creativity",
-  subtitle: "Imagination and creativity Subtitle",
   markdown: markdown_for_imagination_and_creativity,
-  seo: "Early-Years-Foundation-Stage",
   position: 1,
   parent_id: expressive_arts_and_design_page.id,
 }
@@ -67,9 +63,7 @@ This page is still being written.
 MARKDOWN_FOR_SELF_EXPRESSION
 self_expression = {
   title: "Self expression",
-  subtitle: "Self expression Subtitle",
   markdown: markdown_for_self_expression,
-  seo: "Early-Years-Foundation-Stage",
   position: 2,
   parent_id: expressive_arts_and_design_page.id,
 }
@@ -86,9 +80,7 @@ This page is still being written.
 MARKDOWN_FOR_COMMUNICATING_THROUGH_ARTS
 communicating_through_arts = {
   title: "Communicating through arts",
-  subtitle: "Communicating through arts Subtitle",
   markdown: markdown_for_communicating_through_arts,
-  seo: "Early-Years-Foundation-Stage",
   position: 3,
   parent_id: expressive_arts_and_design_page.id,
 }

--- a/db/seeds/get_help_to_improve_your_practice_seeds.rb
+++ b/db/seeds/get_help_to_improve_your_practice_seeds.rb
@@ -21,9 +21,7 @@ MARKDOWN
 
 attrs = {
   title: "Get help to improve your practice",
-  subtitle: "Get help to improve your practice subtitle",
   markdown: markdown,
-  seo: "get-help-to-improve-your-practice",
   position: 8,
 }
 parent_page = ContentPage.new attrs
@@ -42,9 +40,7 @@ MARKDOWN
 
 attrs = {
   title: "Planning",
-  subtitle: "Planning subtitle",
   markdown: markdown,
-  seo: "Planning",
   position: 1,
   parent_id: parent_page.id,
 }
@@ -64,9 +60,7 @@ MARKDOWN
 
 attrs = {
   title: "Reducing paperwork",
-  subtitle: "Reducing paperwork subtitle",
   markdown: markdown,
-  seo: "Reducing-paperwork",
   position: 2,
   parent_id: parent_page.id,
 }
@@ -86,9 +80,7 @@ MARKDOWN
 
 attrs = {
   title: "Identifying and supporting children with special educational needs and disability",
-  subtitle: "Identifying and supporting children with special educational needs and disability (SEND) subtitle",
   markdown: markdown,
-  seo: "Identifying-and-supporting-children-with-special-educational-needs-and-disability",
   position: 3,
   parent_id: parent_page.id,
 }
@@ -107,9 +99,7 @@ MARKDOWN
 
 attrs = {
   title: "Promoting oral health as part of the safeguarding and welfare requirements",
-  subtitle: "Promoting oral health as part of the safeguarding and welfare requirements subtitle",
   markdown: markdown,
-  seo: "promoting-oral-health",
   position: 4,
   parent_id: parent_page.id,
 }
@@ -136,9 +126,7 @@ MARKDOWN
 
 attrs = {
   title: "Working in partnership with parents",
-  subtitle: "Working in partnership with parents subtitle",
   markdown: markdown,
-  seo: "working-in-partnership-with-parents",
   position: 5,
   parent_id: parent_page.id,
 }

--- a/db/seeds/literacy_seeds.rb
+++ b/db/seeds/literacy_seeds.rb
@@ -29,9 +29,7 @@ MARKDOWN_FOR_LITERACY
 
 literacy = {
   title: "Literacy",
-  subtitle: "Literacy subtitle",
   markdown: markdown_for_literacy,
-  seo: "Early-Years-Foundation-Stage",
   position: 4,
 }
 literacy_page = ContentPage.new literacy
@@ -47,9 +45,7 @@ This page is still being written.
 MARKDOWN_FOR_COMPREHENSION
 comprehension = {
   title: "Comprehension",
-  subtitle: "Comprehension Subtitle",
   markdown: markdown_for_comprehension,
-  seo: "Early-Years-Foundation-Stage",
   position: 1,
   parent_id: literacy_page.id,
 }
@@ -66,9 +62,7 @@ This page is still being written.
 MARKDOWN_FOR_WORD_READING
 word_reading = {
   title: "Word reading",
-  subtitle: "Word reading Subtitle",
   markdown: markdown_for_word_reading,
-  seo: "Early-Years-Foundation-Stage",
   position: 2,
   parent_id: literacy_page.id,
 }
@@ -85,9 +79,7 @@ This page is still being written.
 MARKDOWN_FOR_WRITING
 writing = {
   title: "Writing",
-  subtitle: "Writing Subtitle",
   markdown: markdown_for_writing,
-  seo: "Early-Years-Foundation-Stage",
   position: 3,
   parent_id: literacy_page.id,
 }

--- a/db/seeds/mathematics_seeds.rb
+++ b/db/seeds/mathematics_seeds.rb
@@ -30,9 +30,7 @@ MARKDOWN_FOR_MATHEMATICS
 
 mathematics = {
   title: "Maths",
-  subtitle: "Access resources, activity ideas and advice for teaching early years maths.",
   markdown: markdown_for_mathematics,
-  seo: "Early-Years-Foundation-Stage",
   position: 5,
 }
 mathematics_page = ContentPage.new mathematics
@@ -109,9 +107,7 @@ The children are now offered a counting collection in a different area of pre-sc
 MARKDOWN_FOR_COUNTING
 counting = {
   title: "Patterns and connections",
-  subtitle: "Patterns and connections Subtitle",
   markdown: markdown_for_counting,
-  seo: "Early-Years-Foundation-Stage",
   position: 2,
   parent_id: mathematics_page.id,
 }
@@ -128,9 +124,7 @@ This page is still being written.
 MARKDOWN_FOR_NUMBER_PATTERNS
 number_patterns = {
   title: "Numbers in context",
-  subtitle: "Numbers in context Subtitle",
   markdown: markdown_for_number_patterns,
-  seo: "Early-Years-Foundation-Stage",
   position: 1,
   parent_id: mathematics_page.id,
 }
@@ -147,9 +141,7 @@ This page is still being written.
 MARKDOWN_FOR_SPATIAL_REASONING
 spatial_reasoning = {
   title: "Reasoning",
-  subtitle: "Reasoning Subtitle",
   markdown: markdown_for_spatial_reasoning,
-  seo: "Early-Years-Foundation-Stage",
   position: 3,
   parent_id: mathematics_page.id,
 }

--- a/db/seeds/personal_social_and_emotional_development_seeds.rb
+++ b/db/seeds/personal_social_and_emotional_development_seeds.rb
@@ -36,9 +36,7 @@ MARKDOWN_FOR_PERSONAL_SOCIAL_AND_DEVELOPMENT
 
 personal_social_and_emotional_development = {
   title: "Personal, social and emotional development",
-  subtitle: "Access resources, activity ideas and advice for teaching personal, social and emotional development to early years children.",
   markdown: markdown_for_personal_social_and_emotional_development,
-  seo: "Early-Years-Foundation-Stage",
   position: 3,
 }
 personal_social_and_emotional_development_page = ContentPage.new personal_social_and_emotional_development
@@ -304,9 +302,7 @@ Supporting children’s emotional development and wellbeing is linked to all EYF
 MARKDOWN_FOR_EMOTIONS
 emotions = {
   title: "Emotions",
-  subtitle: "Emotions Subtitle",
   markdown: markdown_for_emotions,
-  seo: "Early-Years-Foundation-Stage",
   position: 1,
   parent_id: personal_social_and_emotional_development_page.id,
 }
@@ -323,9 +319,7 @@ This page is still being written.
 MARKDOWN_FOR_RELATIONSHIPS
 relationships = {
   title: "Relationships",
-  subtitle: "Relationships Subtitle",
   markdown: markdown_for_relationships,
-  seo: "Early-Years-Foundation-Stage",
   position: 3,
   parent_id: personal_social_and_emotional_development_page.id,
 }
@@ -468,9 +462,7 @@ Consider how your environment supports children to play independently.
 MARKDOWN_FOR_SENSE_OF_SELF
 sense_of_self = {
   title: "Sense of self",
-  subtitle: "Sense of self Subtitle",
   markdown: markdown_for_sense_of_self,
-  seo: "Early-Years-Foundation-Stage",
   position: 2,
   parent_id: personal_social_and_emotional_development_page.id,
 }

--- a/db/seeds/physical_development.rb
+++ b/db/seeds/physical_development.rb
@@ -38,9 +38,7 @@ MARKDOWN_FOR_PHYSICAL_DEVELOPMENT
 
 physical_development = {
   title: "Physical development",
-  subtitle: "Physical development",
   markdown: markdown_for_physical_development,
-  seo: "Early-Years-Foundation-Stage",
   position: 2,
 }
 physical_development_page = ContentPage.new physical_development
@@ -54,9 +52,7 @@ markdown_for_core_strength = <<-MARKDOWN_FOR_CORE_STRENGTH
 MARKDOWN_FOR_CORE_STRENGTH
 core_strength = {
   title: "Core strength and co-ordination",
-  subtitle: "PCore strength and co-ordination",
   markdown: markdown_for_core_strength,
-  seo: "Early-Years-Foundation-Stage",
   position: 1,
   parent_id: physical_development_page.id,
 }
@@ -68,9 +64,7 @@ markdown_for_fine_motor_skills = <<-MARKDOWN_FOR_FINE_MOTOR_SKILS
 MARKDOWN_FOR_FINE_MOTOR_SKILS
 fine_motor_skills = {
   title: "Fine motor skills",
-  subtitle: "Fine motor skills",
   markdown: markdown_for_fine_motor_skills,
-  seo: "Early-Years-Foundation-Stage",
   position: 3,
   parent_id: physical_development_page.id,
 }
@@ -82,9 +76,7 @@ markdown_for_gross_motor_skills = <<-MARKDOWN_FOR_GROSS_MOTOR_SKILLS
 MARKDOWN_FOR_GROSS_MOTOR_SKILLS
 gross_motor_skills = {
   title: "Gross motor Skills",
-  subtitle: "Gross motor Skills",
   markdown: markdown_for_gross_motor_skills,
-  seo: "Early-Years-Foundation-Stage",
   position: 2,
   parent_id: physical_development_page.id,
 }

--- a/db/seeds/understanding_the_world_seeds.rb
+++ b/db/seeds/understanding_the_world_seeds.rb
@@ -28,9 +28,7 @@ MARKDOWN_FOR_UNDERSTANDING_THE_WORLD
 
 understanding_the_world = {
   title: "Understanding the world",
-  subtitle: "Access resources, activity ideas and advice for teaching understanding the world to early years children.",
   markdown: markdown_for_understanding_the_world,
-  seo: "Early-Years-Foundation-Stage",
   position: 6,
 }
 understanding_the_world_page = ContentPage.new understanding_the_world
@@ -46,9 +44,7 @@ This page is still being written.
 MARKDOWN_FOR_PERSONAL_EXPERIENCES
 personal_experiences = {
   title: "Personal experiences",
-  subtitle: "Personal experiences Subtitle",
   markdown: markdown_for_personal_experiences,
-  seo: "Early-Years-Foundation-Stage",
   position: 1,
   parent_id: understanding_the_world_page.id,
 }
@@ -65,9 +61,7 @@ This page is still being written.
 MARKDOWN_FOR_DIVERSE_WORLD
 diverse_world = {
   title: "Diverse world",
-  subtitle: "Diverse world Subtitle",
   markdown: markdown_for_diverse_world,
-  seo: "Early-Years-Foundation-Stage",
   position: 2,
   parent_id: understanding_the_world_page.id,
 }
@@ -84,9 +78,7 @@ This page is still being written.
 MARKDOWN_FOR_WIDENING_VOCABULARY
 widening_vocabulary = {
   title: "Widening vocabulary",
-  subtitle: "Widening vocabulary Subtitle",
   markdown: markdown_for_widening_vocabulary,
-  seo: "Early-Years-Foundation-Stage",
   position: 3,
   parent_id: understanding_the_world_page.id,
 }

--- a/spec/factories/content_pages.rb
+++ b/spec/factories/content_pages.rb
@@ -9,8 +9,6 @@ end
 FactoryBot.define do
   factory :content_page do
     title { sentence_without_puncutation }
-    subtitle { Faker::Lorem.paragraph }
-    seo { "SEO#{Faker::Lorem.sentence(word_count: 4)}" }
     markdown { Faker::Markdown.headers }
     parent_id { nil }
     position { ContentPage.maximum("position").nil? ? 1 : ContentPage.maximum("position") + 1 }

--- a/spec/views/content_pages/edit.html.erb_spec.rb
+++ b/spec/views/content_pages/edit.html.erb_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe "content_pages/edit", type: :view do
       assert_select "input[name=?]", "content_page[title]"
 
       assert_select "textarea[name=?]", "content_page[markdown]"
-
-      assert_select "input[name=?]", "content_page[seo]"
     end
   end
 end

--- a/spec/views/content_pages/index.html.erb_spec.rb
+++ b/spec/views/content_pages/index.html.erb_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe "content_pages/index", type: :view do
     render
     @content_pages.each do |funky_page|
       rendered.include? funky_page.title
-      rendered.include? funky_page.subtitle
       rendered.include? funky_page.markdown
-      rendered.include? funky_page.seo
     end
   end
 end

--- a/spec/views/content_pages/new.html.erb_spec.rb
+++ b/spec/views/content_pages/new.html.erb_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "content_pages/new", type: :view do
     assign(:content_page, ContentPage.new(
                             title: "MyString",
                             markdown: "MyString",
-                            seo: "MyString",
                           ))
   end
 
@@ -15,11 +14,7 @@ RSpec.describe "content_pages/new", type: :view do
     assert_select "form[action=?][method=?]", content_pages_path, "post" do
       assert_select "input[name=?]", "content_page[title]"
 
-      assert_select "textarea[name=?]", "content_page[subtitle]"
-
       assert_select "textarea[name=?]", "content_page[markdown]"
-
-      assert_select "input[name=?]", "content_page[seo]"
     end
   end
 end

--- a/spec/views/content_pages/show.html.erb_spec.rb
+++ b/spec/views/content_pages/show.html.erb_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe "content_pages/show", type: :view do
   it "renders attributes in <p>" do
     render
     expect(rendered).to include(@content_page.title)
-    expect(rendered).to include(@content_page.subtitle)
-    expect(rendered).to include(@content_page.seo)
     expect(rendered).to include(@content_page.markdown)
   end
 end


### PR DESCRIPTION
### Context
These two attributes are not used

### Changes proposed in this pull request
Remove the seo and subtitle from all views, db table, seeds and tests

### Guidance to review
Check that you can still create and edit a ContentPage
Check it saves itself without needing seo and subtitle
Check that the pages still display
