### PR TITLE
Hfeyp 65 and 118 get help, also 174 (Remove 'stay up to date')

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -6,4 +6,8 @@ module ContentHelper
   def is_current?(page)
     page.slug == params[:slug]
   end
+
+  def find_children_for_page_with_title(title)
+    ContentPage.find_by_title(title)&.children
+  end
 end

--- a/app/views/layouts/_show_links_to_children_of_page_with_title.html.erb
+++ b/app/views/layouts/_show_links_to_children_of_page_with_title.html.erb
@@ -1,0 +1,7 @@
+<div>
+  <h2 class="govuk-heading-l"><%= title_of_page_to_render %></h2>
+
+  <% (find_children_for_page_with_title(title_of_page_to_render) || []).each do |child| %>
+      <p class="govuk-body"><a class="govuk-link" href="<%= path_for_this_page(child) %>"><%= child.title %></a></p>
+  <% end %>
+</div>

--- a/app/views/layouts/landing_page_layout.html.erb
+++ b/app/views/layouts/landing_page_layout.html.erb
@@ -106,13 +106,7 @@
     <div class="govuk-width-container govuk-!-padding-top-8 govuk-!-margin-bottom-7">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-          <h2 class="govuk-heading-l">Get help to improve your practice</h2>
-          <p class="govuk-body">Use the links below to find out how to improve your practice</p>
-          <p class="govuk-body"><a class="govuk-link" href="#">Planning your curriculum</a></p>
-          <p class="govuk-body"><a class="govuk-link" href="#">Reducing paperwork</a></p>
-          <p class="govuk-body"><a class="govuk-link" href="#">Supporting / identifying childrenwith SEND</a></p>
-          <p class="govuk-body"><a class="govuk-link" href="#">Oral health</a></p>
-          <p class="govuk-body"><a class="govuk-link" href="#">Keeping parents up to date</a></p>
+          <%= render partial: 'layouts/show_links_to_children_of_page_with_title', locals: {title_of_page_to_render: "Get help to improve your practice"} %>
           <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
           <h2 class="govuk-heading-l">Other useful resources</h2>
           <p class="govuk-body">Use the links below to find out other resources that may be useful</p>
@@ -123,98 +117,7 @@
       </div>
     </div>
     <!--End of-->
-
-    <!--Signup alert-->
-    <div class="govuk-width-container govuk-!-padding-top-4 govuk-!-margin-bottom-6">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <div class="eyfs-signup-link govuk-!-display-none-print govuk-!-margin-bottom-0 eyfs-signup-link--with-background-and-border">
-            <div class="eyfs-signup-link__inner">
-              <svg class="eyfs-signup-link__icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" height="18" width="18" viewBox="0 0 459.334 459.334">
-                <path fill="black" d="M177.216 404.514c-.001.12-.009.239-.009.359 0 30.078 24.383 54.461 54.461 54.461s54.461-24.383 54.461-54.461c0-.12-.008-.239-.009-.359H175.216zM403.549 336.438l-49.015-72.002v-89.83c0-60.581-43.144-111.079-100.381-122.459V24.485C254.152 10.963 243.19 0 229.667 0s-24.485 10.963-24.485 24.485v27.663c-57.237 11.381-100.381 61.879-100.381 122.459v89.83l-49.015 72.002a24.76 24.76 0 0 0 20.468 38.693H383.08a24.761 24.761 0 0 0 20.469-38.694z"></path>
-              </svg>
-              <h3 class="govuk-heading-s eyfs-signup-link__title">Stay up to date with GOV.UK</h3>
-              <a class="govuk-link govuk-!-font-size-19" href="#">Sign up to get emails when we change any coronavirus
-                information on the GOV.UK website</a>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <!--End of-->
-
-    <!--Social links-->
-    <div class="govuk-width-container govuk-!-padding-top-4">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <p>Share this page</p>
-          <div class="gem-c-share-links gem-c-share-links--columns" data-module="track-click">
-
-            <ul class="gem-c-share-links__list">
-              <li class="gem-c-share-links__list-item">
-                <a target="_blank" rel="noopener noreferrer external" data-track-category="social media" data-track-action="facebook" class="gem-c-share-links__link govuk-!-font-size-16" href="/facebook-share-link">
-                    <span class="gem-c-share-links__link-icon">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" aria-hidden="true">
-                          <path fill="currentColor" d="M31.006 0H.993A.997.997 0 0 0 0 .993v30.014c0 .55.452.993.993.993h30.013a.998.998 0 0 0 .994-.993V.993A.999.999 0 0 0 31.006 0z"></path>
-                          <path fill="#FFF" d="M17.892 10.751h1.787V8.009L17.216 8c-2.73 0-3.352 2.045-3.352 3.353v1.828h-1.581v2.824h1.581V24h3.322v-7.995h2.242l.291-2.824h-2.533V11.52c.001-.623.415-.769.706-.769z"></path>
-                        </svg>
-                    </span>
-                  <span class="govuk-visually-hidden">
-                      Share on
-                    </span>
-                  Facebook
-                </a>
-              </li>
-
-              <li class="gem-c-share-links__list-item">
-                <a target="_blank" rel="noopener noreferrer external" data-track-category="social media" data-track-action="facebook" class="gem-c-share-links__link govuk-!-font-size-16" href="/facebook-share-link">
-                    <span class="gem-c-share-links__link-icon">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" aria-hidden="true"><path d="M0 32V0h32v32H0zm20.839-13.894c-.263-.131-1.555-.766-1.796-.854-.24-.088-.416-.132-.59.131-.176.263-.68.855-.833 1.03-.153.176-.307.198-.57.066-.262-.131-1.109-.41-2.113-1.304-.78-.697-1.308-1.557-1.461-1.82-.153-.263-.016-.406.115-.536.118-.118.263-.308.394-.46.131-.154.175-.264.263-.44.088-.174.044-.328-.022-.46-.066-.131-.591-1.424-.81-1.95-.214-.513-.43-.443-.59-.452a10.506 10.506 0 00-.505-.009.964.964 0 00-.7.329c-.241.263-.92.899-.92 2.192 0 1.293.942 2.542 1.073 2.718.131.176 1.852 2.83 4.489 3.967.626.27 1.116.433 1.497.554.63.2 1.202.172 1.655.104.505-.075 1.555-.636 1.774-1.25.219-.613.219-1.14.153-1.25-.066-.108-.24-.174-.503-.306zm-4.795 6.547h-.003a8.73 8.73 0 01-4.449-1.219l-.319-.19-3.308.869.883-3.226-.208-.33a8.718 8.718 0 01-1.336-4.652c.001-4.819 3.922-8.74 8.744-8.74a8.68 8.68 0 016.179 2.564 8.686 8.686 0 012.557 6.183c-.002 4.82-3.922 8.74-8.74 8.74zm7.44-16.18a10.449 10.449 0 00-7.44-3.084c-5.796 0-10.513 4.717-10.516 10.516 0 1.853.484 3.662 1.404 5.256l-1.492 5.45 5.574-1.463a10.504 10.504 0 005.026 1.28h.004c5.796 0 10.514-4.717 10.516-10.515a10.455 10.455 0 00-3.077-7.44z" fill="currentColor"/></svg>
-
-                    </span>
-                  <span class="govuk-visually-hidden">
-                      Share on
-                    </span>
-                  WhatsApp
-                </a>
-              </li>
-
-              <li class="gem-c-share-links__list-item">
-                <a target="_blank" rel="noopener noreferrer external" data-track-category="social media" data-track-action="email" class="gem-c-share-links__link govuk-!-font-size-16" href="/email-share-link">
-                  <span class="gem-c-share-links__link-icon">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="9 9 32 32" aria-hidden="true"><path fill="currentColor" d="M9 9h32v32H9V9z"></path><path fill="#FFF" d="M34.983 18.76v12.48H15.016V18.76h19.967m2.496-2.496H12.52v17.472h24.959V16.264z"></path><path fill="none" stroke="#FFF" stroke-width="2.496" stroke-miterlimit="10" d="M14.59 18.963L25 26.945l10.263-7.869"></path></svg>
-                  </span>
-                  <span class="govuk-visually-hidden">
-                    Share on
-                  </span>
-                  Email
-                </a>
-              </li>
-
-              <li class="gem-c-share-links__list-item">
-                <a target="_blank" rel="noopener noreferrer external" data-track-category="social media" data-track-action="twitter" class="gem-c-share-links__link govuk-!-font-size-16" href="/twitter-share-link">
-                  <span class="gem-c-share-links__link-icon">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" aria-hidden="true">
-                      <path fill="currentColor" d="M31.007 0H.993A.999.999 0 0 0 0 .993v30.014c0 .55.452.993.993.993h30.014a.997.997 0 0 0 .993-.993V.993A.998.998 0 0 0 31.007 0z"></path>
-                      <path fill="#FFF" d="M8 21.027a9.286 9.286 0 0 0 5.032 1.475c6.038 0 9.34-5.002 9.34-9.339 0-.143-.004-.284-.012-.425a6.619 6.619 0 0 0 1.639-1.699c-.6.265-1.234.439-1.885.516a3.287 3.287 0 0 0 1.443-1.816 6.571 6.571 0 0 1-2.086.797 3.28 3.28 0 0 0-5.592 2.993 9.311 9.311 0 0 1-6.766-3.43 3.294 3.294 0 0 0-.443 1.651 3.28 3.28 0 0 0 1.46 2.732 3.278 3.278 0 0 1-1.488-.411v.041a3.288 3.288 0 0 0 2.633 3.22 3.28 3.28 0 0 1-1.481.055 3.285 3.285 0 0 0 3.065 2.281 6.59 6.59 0 0 1-4.076 1.404A6.76 6.76 0 0 1 8 21.027z"></path>
-                    </svg>
-                  </span>
-                  <span class="govuk-visually-hidden">
-                      Share on
-                  </span>
-                  Twitter
-                </a>
-              </li>
-            </ul>
-          </div>
-
-        </div>
-      </div>
-    </div>
-    <!--End of-->
-
   </main>
-
 </div>
 
 

--- a/db/seeds/get_help_to_improve_your_practice_seeds.rb
+++ b/db/seeds/get_help_to_improve_your_practice_seeds.rb
@@ -20,7 +20,7 @@ Working in partnership with parents
 MARKDOWN
 
 attrs = {
-  title: "Get help to improve your practice",
+  title: "Get help to improve your practice (SEND)",
   markdown: markdown,
   position: 8,
 }

--- a/db/seeds/get_help_to_improve_your_practice_seeds.rb
+++ b/db/seeds/get_help_to_improve_your_practice_seeds.rb
@@ -20,7 +20,7 @@ Working in partnership with parents
 MARKDOWN
 
 attrs = {
-  title: "Get help to improve your practice (SEND)",
+  title: "Get help to improve your practice",
   markdown: markdown,
   position: 8,
 }


### PR DESCRIPTION
### Context
The landing page has a section low down called "Get help to improve your practice". It was hard coded.
It now contains links to the children of the top level page with the same name.
So if a child is added to "Get help to improve your practice", its link will show up in the landing page.

### Changes proposed in this pull request
The landing page has a section low down called "Get help to improve your practice". It was hard coded.
It now contains links to the children of the top level page with the same name.
So if a child is added to "Get help to improve your practice", its link will show up in the landing page.

I have also removed the grey box and social media icons at the bottom of the landing page, as per HFEYP-174, 

### Guidance to review
Check that the landing page contains a section low down called "Get help to improve your practice" and that the links go to all of the children of this page.

Check that the grey box and social media icons at the bottom of the landing page have been removed

https://dfedigital.atlassian.net/browse/HFEYP-65

https://dfedigital.atlassian.net/browse/HFEYP-118

https://dfedigital.atlassian.net/browse/HFEYP-174
