### PR TITLE
Restricting web_app resource to read only binding of postgres

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -25,6 +25,7 @@ resource cloudfoundry_app web_app {
     for_each = local.app_service_bindings
     content {
       service_instance = service_binding.value
+      params = {"read_only": true}
     }
   }
   routes {


### PR DESCRIPTION
### Context

With two versions of the application deployed on separate instances, one for the CMS and another for the website. They both share the same Postgres database instance but only the CMS application should be able to read and write to the database.

### Changes proposed in this pull request

This PR restricts the binding to Postgres to be read only for the website instance. Removing write permissions.
Write permissions would still remain for the CMS instance

### Guidance to review

