### PR TITLE
Service binding read_only values requires string

### DIFF
--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -25,7 +25,7 @@ resource cloudfoundry_app web_app {
     for_each = local.app_service_bindings
     content {
       service_instance = service_binding.value
-      params = {"read_only": true}
+      params = {"read_only": "true"}
     }
   }
   routes {


### PR DESCRIPTION
### Context

Fixing the following error:

```

Error: Service broker error: json: cannot unmarshal string into Go struct field BindParameters.read_only of type bool

  on modules/paas/main.tf line 11, in resource "cloudfoundry_app" "web_app":
  11: resource cloudfoundry_app web_app {
```

### Changes proposed in this pull request

Converted the bool value to string

### Guidance to review

