### PR TITLE
Add DNS route mapping to prod deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,3 +119,21 @@ jobs:
           terraform init -reconfigure -input=false -backend-config="bucket=${{secrets.AWS_BUCKET_PROD}}"
           terraform plan -var-file ../workspace-variables/prod.tfvars
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/prod.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_PROD}}", "AWS_ACCESS_KEY_ID": "${{secrets.AWS_ACCESS_KEY_ID_PROD}}", "AWS_SECRET_ACCESS_KEY": "${{secrets.AWS_SECRET_ACCESS_KEY_PROD}}", "AWS_REGION": "${{secrets.AWS_REGION}}", "AWS_BUCKET": "${{secrets.AWS_BUCKET_PROD}}", "BASIC_AUTH_USER": "${{secrets.BASIC_AUTH_USER}}", "BASIC_AUTH_PASSWORD": "${{secrets.BASIC_AUTH_PASSWORD}}"}'
+
+      - name: Install CF CLI on Prod
+        uses: DFE-Digital/github-actions/setup-cf-cli@master
+        if: ${{ github.event.inputs.environment == 'prod' }}
+        with:
+          CF_USERNAME: ${{ secrets.GOVPAAS_USERNAME_PROD }}
+          CF_PASSWORD: ${{ secrets.GOVPAAS_PASSWORD_PROD }}
+          CF_SPACE_NAME: eyfs-${{ github.event.inputs.environment }} # required
+          # Optional inputs
+          CF_CLI_VERSION: v7 # default v7, allowed values: v6 or v7
+          CF_ORG_NAME: dfe # default
+          CF_API_URL:  https://api.london.cloud.service.gov.uk # default
+          INSTALL_CONDUIT: false # default: false
+
+      - name: Remap DNS route on Prod
+        if: ${{ github.event.inputs.environment == 'prod' }}
+        run: |
+          cf map-route eyfs-prod education.gov.uk --hostname help-for-early-years-providers


### PR DESCRIPTION
### Context

On deploy to production the DNS route is lost, meaning the domain 404s

### Changes proposed in this pull request

Remaps the DNS route after deploying to production

### Guidance to review

