### PR TITLE
Force all access to the app over SSL, use Strict-Transport-Security, …

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   config.active_storage.service = :amazon
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
…and use secure cookies

### Context

Session Cookie was identified as missing the Secure Flag.

### Changes proposed in this pull request

Force ssl for all requests

### Guidance to review

