### PR TITLE
Undo last PR

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem "listen", ">= 3.0.5", "< 3.6"
+  gem "listen", ">= 3.0.5", "< 3.5"
   gem "web-console", ">= 3.3.0"
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
     kgio (2.11.3)
     kramdown (2.3.1)
       rexml
-    listen (3.5.0)
+    listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logstasher (2.1.5)
@@ -229,15 +229,11 @@ GEM
     middleware (0.1.0)
     mimemagic (0.3.5)
     mini_mime (1.0.2)
-    mini_portile2 (2.5.0)
     minitest (5.14.4)
     msgpack (1.4.2)
     multi_test (0.1.2)
     multipart-post (2.1.1)
     nio4r (2.5.7)
-    nokogiri (1.11.2)
-      mini_portile2 (~> 2.5.0)
-      racc (~> 1.4)
     nokogiri (1.11.2-x86_64-darwin)
       racc (~> 1.4)
     nokogumbo (2.0.5)
@@ -434,7 +430,6 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  ruby
   x86_64-darwin-19
 
 DEPENDENCIES
@@ -457,7 +452,7 @@ DEPENDENCIES
   foreman
   govspeak
   htmlentities (= 4.3.4)
-  listen (>= 3.0.5, < 3.6)
+  listen (>= 3.0.5, < 3.5)
   pg (>= 0.18, < 2.0)
   pry-byebug
   puma (~> 5.2)


### PR DESCRIPTION
### Context
The previous merge broke deployments (it passed all tests)
So undoing
It was an automatic suggestion of upgrading the version of the listen gem

### Changes proposed in this pull request

### Guidance to review

