### PR TITLE
282 - Next and Previous pages now stored in the ContentPage record

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Department for Education - Digital
+Copyright (c) 2021 Department for Education - Digital
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -17,7 +17,7 @@ class ContentPage < ApplicationRecord
 
   before_save :set_slug_from_title
 
-  after_commit do
+  after_create do
     ContentPage.reorder
   end
 
@@ -37,34 +37,16 @@ class ContentPage < ApplicationRecord
   end
 
   def next_page
-    my_index = ContentPage.ordering.index(self)
-
-    # Last page uses the first page as next
-    if self == ContentPage.ordering.last
-      my_index = -1
-    end
-
-    ContentPage.ordering[my_index + 1]
+    ContentPage.find next_id
   end
 
   def previous_page
-    my_index = ContentPage.ordering.index(self)
-    # The page before the first just works out as the last page
-    ContentPage.ordering[my_index - 1]
+    ContentPage.find previous_id
   end
 
-  # Avoid hitting the database every time we need the next
-  # page. Memoize the ordering instead
+  # Call if a page is created, destroyed or a position changes
   class << self
-    def ordering
-      @ordering ||= page_ordering
-    end
-
     def reorder
-      @ordering = page_ordering
-    end
-
-    def page_ordering
       page_order = []
 
       ContentPage.top_level.order_by_position.each do |p|
@@ -74,7 +56,21 @@ class ContentPage < ApplicationRecord
         end
       end
 
-      page_order
+      page_order.each_with_index do |page, index|
+        page.next_id = if page == page_order.last
+                         page_order.first.id
+                       else
+                         page_order[index + 1].id
+                       end
+
+        page.previous_id = if page == page_order.first
+                             page_order.last.id
+                           else
+                             page_order[index - 1].id
+                           end
+
+        page.save!
+      end
     end
   end
 end

--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -21,6 +21,12 @@ class ContentPage < ApplicationRecord
     ContentPage.reorder
   end
 
+  after_save do
+    if saved_change_to_position?
+      ContentPage.reorder
+    end
+  end
+
   def full_path
     if parent
       "/" + parent.slug.to_s + "/" + slug.to_s
@@ -44,7 +50,7 @@ class ContentPage < ApplicationRecord
     ContentPage.find previous_id
   end
 
-  # Call if a page is created, destroyed or a position changes
+  # Called when a page is created or a position attribute changes
   class << self
     def reorder
       page_order = []

--- a/app/views/content_pages/_details_for_a_single_page.erb
+++ b/app/views/content_pages/_details_for_a_single_page.erb
@@ -12,7 +12,7 @@
   </div>
   <div>
     <ul class="govuk-list">
-      <% page_to_render.children.each_with_index do |child, index| %>
+      <% page_to_render.children.order_by_position.each_with_index do |child, index| %>
         <li>
           <%= render partial: 'details_for_a_single_page', locals: {page_to_render: child, level: level + 1} %>
         </li>

--- a/db/migrate/20210324120426_add_pagination_to_content_pages.rb
+++ b/db/migrate/20210324120426_add_pagination_to_content_pages.rb
@@ -1,0 +1,11 @@
+class AddPaginationToContentPages < ActiveRecord::Migration[6.1]
+  def self.up
+    add_column :content_pages, :next_id, :integer
+    add_column :content_pages, :previous_id, :integer
+  end
+
+  def self.down
+    remove_column :content_pages, :next_id
+    remove_column :content_pages, :previous_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_11_123635) do
+ActiveRecord::Schema.define(version: 2021_03_24_120426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,8 @@ ActiveRecord::Schema.define(version: 2021_03_11_123635) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "parent_id"
     t.integer "position"
+    t.integer "next_id"
+    t.integer "previous_id"
     t.index ["position", "parent_id"], name: "index_content_pages_on_position_and_parent_id", unique: true
     t.index ["title"], name: "index_content_pages_on_title", unique: true
   end

--- a/spec/models/content_page_spec.rb
+++ b/spec/models/content_page_spec.rb
@@ -76,6 +76,15 @@ RSpec.describe ContentPage, type: :model do
 
       @child1_of_top_level2 = FactoryBot.create(:content_page, position: 1, parent_id: @top_level2.id)
       @child2_of_top_level2 = FactoryBot.create(:content_page, position: 2, parent_id: @top_level2.id)
+
+      # The reordering happens after_create, so need to refetch these
+      # to get their updated next/previous state
+      @top_level1 = ContentPage.find @top_level1.id
+      @top_level2 = ContentPage.find @top_level2.id
+      @child1_of_top_level1 = ContentPage.find @child1_of_top_level1.id
+      @child2_of_top_level1 = ContentPage.find @child2_of_top_level1.id
+      @child1_of_top_level2 = ContentPage.find @child1_of_top_level2.id
+      @child2_of_top_level2 = ContentPage.find @child2_of_top_level2.id
     end
 
     context "Navigating to the Next page" do
@@ -107,6 +116,9 @@ RSpec.describe ContentPage, type: :model do
 
       it "Should reorder the pages when a page is changed" do
         @page_in_the_middle = FactoryBot.create(:content_page, position: 5)
+        # The reordering happens after_create, so need to refetch these
+        @page_in_the_middle = ContentPage.find @page_in_the_middle.id
+        @child2_of_top_level1 = ContentPage.find @child2_of_top_level1.id
         expect(@child2_of_top_level1.next_page).to eq(@page_in_the_middle)
       end
     end


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/HFEYP-282

Currently the next and previous pages are held in memory in a collection. The trouble is that we use two apps, so the second app does not get to update its copy of this ordering when a change is made

Note: after deploying this to production, someone will need to open a rails console and run

```
ContentPage::reorder
```

### Changes proposed in this pull request
The ContentPage table now has next_id and previous_id columns
After a page is created, a class method called ContentPage::reorder is called to update all prev/next values and save the changes

### Guidance to review
On the cms site, check that Prev/Next work
Add a page and check again
Check on the non-cms site that the new ordering is shown

Do this again after changing the position of a child page

