### PR TITLE
Hfeyp 155 accessibility landmarks

### DIFF
--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -1,4 +1,4 @@
-<main class="govuk-main-wrapper" id="main-content">
+<div class="govuk-main-wrapper" id="main-content">
   <div class="govuk-width-container govuk-!-margin-bottom-7">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds landing-page_header-text-container govuk-!-margin-bottom-0 govuk-!-padding-bottom-0">
@@ -47,4 +47,4 @@
       </div>
     </div>
     <!--End of-->
-</main>
+</div>

--- a/app/views/layouts/cms.html.erb
+++ b/app/views/layouts/cms.html.erb
@@ -67,7 +67,7 @@
       <div class="govuk-main-wrapper" >
         <%= yield %>
       </div>
-    </div>
+    </main>
 
     <footer class="govuk-footer " role="contentinfo">
       <%= render 'layouts/footer_content' %>

--- a/app/views/layouts/cms.html.erb
+++ b/app/views/layouts/cms.html.erb
@@ -24,9 +24,8 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 
-    <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-
     <header class="govuk-header app-header" role="banner" data-module="govuk-header">
+      <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
           <%= link_to "https://www.gov.uk/", class: "govuk-header__link govuk-header__link--homepage" do %>
@@ -63,15 +62,11 @@
         </div>
       </div>
     </header>
-    <div class="govuk-width-container">
 
-      <%= render 'layouts/phase_banner' %>
-    </div>
-
-    <div class="govuk-width-container">
-      <main class="govuk-main-wrapper " id="main-content" role="main">
+    <main role="main" id="main-content" class="govuk-width-container">
+      <div class="govuk-main-wrapper" >
         <%= yield %>
-      </main>
+      </div>
     </div>
 
     <footer class="govuk-footer " role="contentinfo">

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -55,22 +55,24 @@
   </div>
   </header>
 
-  <div class="govuk-width-container">
-    <%= render 'layouts/mobile_menu' %>
+  <aside class="govuk-width-container" role="complementary">
     <%= render 'layouts/phase_banner' %>
+  </aside>
+
+  <nav class="govuk-width-container" role="navigation">
+    <%= render 'layouts/mobile_menu' %>
     <%= render 'layouts/breadcrumbs' %>
-  </div>
+  </nav>
 
-
-  <div class="govuk-width-container">
+  <main class="govuk-width-container" role="main">
     <div class="govuk-main-wrapper">
       <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-third desktop-menu">
+        <nav role="navigation" class="govuk-grid-column-one-third desktop-menu">
           <%= render 'layouts/desktop_menu' %>
-        </div>
+        </nav>
 
         <div class="govuk-grid-column-two-thirds">
-          <main id="main-content" class="app-content gem-c-govspeak" role="main">
+          <div id="main-content" class="app-content gem-c-govspeak">
             <%= yield %>
             <nav class="gem-c-pagination" role="navigation" aria-label="Pagination">
               <ul class="gem-c-pagination__list">
@@ -104,7 +106,7 @@
                 </li>
               </ul>
             </nav>
-          </main>
+          </div>
 
           <div class="eyfs-helpful-tools">
             <div class="app-back-to-top govuk-!-margin-bottom-7" data-module="app-back-to-top">
@@ -121,7 +123,7 @@
         </div>
       </div>
     </div>
-  </div>
+  </main>
 
   <footer class="govuk-footer " role="contentinfo">
     <%= render 'layouts/footer_content' %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -26,13 +26,12 @@
   </script>
   <%= render 'layouts/google_analytics_body' if cookies[:track_google_analytics] == 'Yes' %>
 
-  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-
   <% if !cookies[:track_google_analytics] %>
   <%= render 'layouts/cookies_notice'  %>
   <% end %>
 
   <header class="govuk-header app-header" role="banner" data-module="govuk-header">
+  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo govuk-!-padding-right-0">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -24,9 +24,9 @@
   document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 </script>
 
-<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
   <header class="govuk-header app-header" role="banner" data-module="govuk-header">
+  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo govuk-!-padding-right-0">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
@@ -50,17 +50,17 @@
   </div>
   </header>
   
-<div class="govuk-width-container">
+<aside role="complementary" class="govuk-width-container">
   <%= render 'layouts/phase_banner' %>
-</div>
+</aside>
 
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper " id="main-content" role="main">
+<main role="main" class="govuk-width-container">
+  <div class="govuk-main-wrapper" id="main-content">
     <%= yield %>
-  </main>
-</div>
+  </div>
+</main>
 
-<footer class="govuk-footer " role="contentinfo">
+<footer class="govuk-footer" role="contentinfo">
   <%= render 'layouts/footer_content' %>
 </footer>
 </body>

--- a/app/views/layouts/landing_page_layout.html.erb
+++ b/app/views/layouts/landing_page_layout.html.erb
@@ -27,13 +27,13 @@
 
 <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 <%= render 'layouts/google_analytics_body' if cookies[:track_google_analytics] == 'Yes' %>
-<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
 <% if !cookies[:track_google_analytics] %>
 <%= render 'layouts/cookies_notice'  %>
 <% end %>
 
 <header class="govuk-header app-header" role="banner" data-module="govuk-header">
+<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo govuk-!-padding-right-0">
       <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">

--- a/app/views/layouts/landing_page_layout.html.erb
+++ b/app/views/layouts/landing_page_layout.html.erb
@@ -56,10 +56,13 @@
   </div>
 </header>
 
-<main class="eyfs-wrapper" role="main">
+<aside role="complementary">
   <div class="govuk-width-container">
     <%= render 'layouts/phase_banner' %>
   </div>
+</aside>
+
+<main class="eyfs-wrapper" role="main">
   <%= yield %>
 </main>
 

--- a/app/views/layouts/landing_page_layout.html.erb
+++ b/app/views/layouts/landing_page_layout.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="govuk-template ">
+<html lang="en" class="govuk-template">
 <head>
   <meta charset="utf-8">
   <title>
@@ -23,7 +23,7 @@
 
   <meta property="og:image" content="/govuk/assets/images/govuk-opengraph-image.png">
 </head>
-<body class="govuk-template__body ">
+<body class="govuk-template__body">
 
 <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 <%= render 'layouts/google_analytics_body' if cookies[:track_google_analytics] == 'Yes' %>
@@ -56,16 +56,14 @@
   </div>
 </header>
 
-<div class="eyfs-wrapper">
-
+<main class="eyfs-wrapper" role="main">
   <div class="govuk-width-container">
     <%= render 'layouts/phase_banner' %>
   </div>
-
   <%= yield %>
-</div>
+</main>
 
-<footer class="govuk-footer " role="contentinfo">
+<footer class="govuk-footer" role="contentinfo">
   <%= render 'layouts/footer_content' %>
 </footer>
 </body>

--- a/app/views/layouts/settings.html.erb
+++ b/app/views/layouts/settings.html.erb
@@ -54,17 +54,15 @@
   </header>
 
 
-  <div class="govuk-width-container">
+  <main class="govuk-width-container" role="main">
     <div class="govuk-main-wrapper">
       <div class="govuk-grid-row">
-
-          <main id="main-content" class="app-content gem-c-govspeak" role="main">
+          <div id="main-content" class="app-content gem-c-govspeak">
             <%= yield %>
-          </main>
-
+          </div>
       </div>
     </div>
-  </div>
+  </main>
 
   <footer class="govuk-footer " role="contentinfo">
     <div class="govuk-width-container ">


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/jira/software/projects/HFEYP/boards/83?selectedIssue=HFEYP-155
Content should be contained within HTML5 landmarks

### Changes proposed in this pull request
- "main" landmark used for main body content (id=mainContent used to tab most appropriate section of "main")
- "aside" landmark - moved phase banner into "aside role="complementary""  landmark as it is not part of main content nor is it a "nav" element
- moved skip links into header

### Guidance to review
- Check content is within HTML5 landmarks - header, aside, nav, main, footer
- Check page styling and functionality e.g, links and tabbing on the page remains unaffected by the changes

