### PR TITLE
HFEYP-49 Add Govspeak Decorator

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,3 @@
+version: "3.9"
+services:
+

--- a/.env.docker
+++ b/.env.docker
@@ -1,7 +1,0 @@
-DATABASE_NAME=govuk_rails_boilerplate_development
-DATABASE_USER=boilerplate_user
-DATABASE_PASSWORD=secretpassword
-DATABASE_HOST=database
-NODE_ENV=development
-POSTGRES_PASSWORD=secretpassword
-WEBPACKER_DEV_SERVER_HOST=0.0.0.0

--- a/.env.docker
+++ b/.env.docker
@@ -1,0 +1,7 @@
+DATABASE_NAME=govuk_rails_boilerplate_development
+DATABASE_USER=boilerplate_user
+DATABASE_PASSWORD=secretpassword
+DATABASE_HOST=database
+NODE_ENV=development
+POSTGRES_PASSWORD=secretpassword
+WEBPACKER_DEV_SERVER_HOST=0.0.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ yarn-debug.log*
 .yarn-integrity
 
 .env
+.env.docker
+.env.localhost
 *.log
 /.idea
 .DS_Store

--- a/app/models/govspeak_decorator.rb
+++ b/app/models/govspeak_decorator.rb
@@ -1,0 +1,75 @@
+class GovspeakDecorator < DelegateClass(Govspeak::Document)
+  Govspeak::Document.extension("YoutubeVideo", /\$YoutubeVideo(?:\[(.*?)\])?\((.*?)\)\$EndYoutubeVideo/m) do |title, youtube_link|
+    youtube_id = youtube_link.scan(/^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/)[0][1]
+    embed_url = %(https://www.youtube.com/embed/#{youtube_id}?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.help-for-early-years.education.gov.uk)
+    optional_title = title ? %(title="#{title}") : ""
+    %(<iframe class="govspeak-embed-video" width="500" height="281" src="#{embed_url}" #{optional_title} frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
+  end
+
+  def to_html
+    @to_html ||= begin
+      html = if sanitize? # @options[:sanitize]
+               raw_html = HtmlSanitizerDecorator.new(kramdown_doc.to_html)
+               raw_html.sanitize(allowed_elements: allowed_elements)
+             else
+               kramdown_doc.to_html
+      end
+      Govspeak::PostProcessor.process(html, self)
+    end
+  end
+
+  def sanitize?
+    __getobj__.instance_variable_get(:@options)[:sanitize] == true
+  end
+
+  def kramdown_doc
+    __getobj__.send("kramdown_doc")
+  end
+
+  def allowed_elements
+    __getobj__.instance_variable_get(:@allowed_elements)
+  end
+
+  class HtmlSanitizerDecorator < Govspeak::HtmlSanitizer
+    class YoutubeTransformer
+      def call(sanitize_context)
+        node      = sanitize_context[:node]
+        node_name = sanitize_context[:node_name]
+
+        # Don't continue if this node is already allowlisted or is not an element.
+        return if sanitize_context[:is_allowlisted] || !node.element?
+
+        # Don't continue unless the node is an iframe.
+        return unless node_name == "iframe"
+
+        # Verify that the video URL is actually a valid YouTube video URL.
+        return unless node["src"] =~ %r{\A(?:https?:)?//(?:www\.)?((youtube)|(youtu\.be))(?:-nocookie)?\.com/}
+
+        # We're now certain that this is a YouTube embed, but we still need to run
+        # it through a special Sanitize step to ensure that no unwanted elements or
+        # attributes that don't belong in a YouTube embed can sneak in.
+        Sanitize.node!(node, {
+          elements: %w[iframe],
+
+          attributes: {
+            "iframe" => %w[allowfullscreen frameborder height src width title allow],
+          },
+        })
+
+        # Now that we're sure that this is a valid YouTube embed and that there are
+        # no unwanted elements or attributes hidden inside it, we can tell Sanitize
+        # to allowlist the current node.
+        { node_allowlist: [node] }
+      end
+    end
+
+    def sanitize(allowed_elements: [])
+      transformers = [TableCellTextAlignWhitelister.new, YoutubeTransformer.new]
+      if @allowed_image_hosts && @allowed_image_hosts.any?
+        transformers << ImageSourceWhitelister.new(@allowed_image_hosts)
+      end
+
+      Sanitize.clean(@dirty_html, Sanitize::Config.merge(sanitize_config(allowed_elements: allowed_elements), transformers: transformers))
+    end
+  end
+end

--- a/app/models/govspeak_decorator.rb
+++ b/app/models/govspeak_decorator.rb
@@ -13,7 +13,7 @@ class GovspeakDecorator < DelegateClass(Govspeak::Document)
                raw_html.sanitize(allowed_elements: allowed_elements)
              else
                kramdown_doc.to_html
-      end
+             end
       Govspeak::PostProcessor.process(html, self)
     end
   end

--- a/app/models/govspeak_decorator.rb
+++ b/app/models/govspeak_decorator.rb
@@ -3,7 +3,7 @@ class GovspeakDecorator < DelegateClass(Govspeak::Document)
     youtube_id = youtube_link.scan(/^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/)[0][1]
     embed_url = %(https://www.youtube.com/embed/#{youtube_id}?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.help-for-early-years.education.gov.uk)
     optional_title = title ? %(title="#{title}") : ""
-    %(<iframe class="govspeak-embed-video" width="500" height="281" src="#{embed_url}" #{optional_title} frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
+    %(<iframe class="govspeak-embed-video" src="#{embed_url}" #{optional_title} frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>)
   end
 
   def to_html

--- a/app/services/govspeak_to_html.rb
+++ b/app/services/govspeak_to_html.rb
@@ -7,6 +7,6 @@ class GovspeakToHTML
   end
 
   def doc(markdown)
-    doc = Govspeak::Document.new(markdown, sanitize: true, allowed_elements: ALLOWED_TAGS)
+    Govspeak::Document.new(markdown, sanitize: true, allowed_elements: ALLOWED_TAGS)
   end
 end

--- a/app/services/govspeak_to_html.rb
+++ b/app/services/govspeak_to_html.rb
@@ -1,8 +1,12 @@
 class GovspeakToHTML
-  ALLOWED_TAGS = %w[details summary p h1 h2 h3 h4 ul li img div ol a span strong].freeze
+  ALLOWED_TAGS = %w[details summary p h1 h2 h3 h4 ul li img div ol a span strong iframe].freeze
 
   def translate_markdown(markdown)
+    newdoc = GovspeakDecorator.new(doc(markdown))
+    newdoc.to_html
+  end
+
+  def doc(markdown)
     doc = Govspeak::Document.new(markdown, sanitize: true, allowed_elements: ALLOWED_TAGS)
-    doc.to_html
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,4 +56,5 @@ Rails.application.configure do
 
   config.hosts << "eyfs-dev.london.cloudapps.digital"
   config.hosts << "cms.lvh.me"
+  config.hosts << "ebrett.ngrok.io"
 end

--- a/db/seeds/communication_and_language_seeds.rb
+++ b/db/seeds/communication_and_language_seeds.rb
@@ -132,7 +132,8 @@ From birth, babies want to connect with others and are eager to interact. For ex
 Being with others helps children to build social relationships which provide opportunities for friendship, empathy and sharing emotions.
 Research shows that high-quality interactions between adults and children make a big difference to how well communication and language skills develop. Children benefit from the company of responsive and enthusiastic adults who are genuinely interested in talking to them.
 In this video, an early years interactions expert explains what has changed within the early years foundation stage framework on interactions, and why. There are also some tips on getting the most out of a child in this area.
-[![Early Years Foundation Stage: Children build a number line](http://img.youtube.com/vi/SYhhCcokBF8/0.jpg)](http://www.youtube.com/watch?v=SYhhCcokBF8)
+
+$YoutubeVideo[Early Years Foundation Stage: Children build a number line](http://www.youtube.com/watch?v=SYhhCcokBF8)$EndYoutubeVideo
 
 ## What the early years foundation stage (EYFS) framework says
 Children's back-and-forth interactions from an early age form the foundations for language and mental development.

--- a/db/seeds/mathematics_seeds.rb
+++ b/db/seeds/mathematics_seeds.rb
@@ -50,7 +50,7 @@ It is an often overlooked fact that we all, whether children or adults, are cons
 
 In this video, an expert in early years maths explains what’s changed in the new EYFS for counting in maths and offers some top tips on getting the most out of a child in this area.
 
-[![IMAGE ALT TEXT HERE](http://img.youtube.com/vi/SYhhCcokBF8/0.jpg)](http://www.youtube.com/watch?v=SYhhCcokBF8)
+$YoutubeVideo[IMAGE ALT TEXT HERE](http://www.youtube.com/watch?v=SYhhCcokBF8)$EndYoutubeVideo
 
 ### Video transcript
 

--- a/spec/models/govspeak_spec.rb
+++ b/spec/models/govspeak_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe GovspeakDecorator do
+  it "passes a simple smoke test" do
+    rendered = GovspeakToHTML.new.translate_markdown("*this is markdown*")
+    expect(rendered).to eq "<p><em>this is markdown</em></p>\n"
+  end
+
+  it "embeds YouTube  as iframe" do
+    govspeak_md = "$YoutubeVideo(https://www.youtube.com/watch?v=ABCDEFGHIJ)$EndYoutubeVideo"
+    expected_html = %(<iframe width="500" height="281" src="https://www.youtube.com/embed/ABCDEFGHIJ?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.help-for-early-years.education.gov.uk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>\n)
+    rendered = GovspeakToHTML.new.translate_markdown(govspeak_md)
+    expect(rendered).to eq(expected_html)
+  end
+
+  it "Youtube Embedding with title" do
+    govspeak_md = "$YoutubeVideo[Test title](https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo"
+    expected_html = %(<iframe width="500" height="281" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.help-for-early-years.education.gov.uk" title="Test title" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>\n)
+    rendered = GovspeakToHTML.new.translate_markdown(govspeak_md)
+    expect(rendered).to eq(expected_html)
+  end
+
+  it "Youtube Embedding without title" do
+    govspeak_md = "$YoutubeVideo(https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo"
+    expected_html = %(<iframe width="500" height="281" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.help-for-early-years.education.gov.uk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>\n)
+    rendered = GovspeakToHTML.new.translate_markdown(govspeak_md)
+    expect(rendered).to eq(expected_html)
+  end
+end

--- a/spec/models/govspeak_spec.rb
+++ b/spec/models/govspeak_spec.rb
@@ -8,21 +8,21 @@ RSpec.describe GovspeakDecorator do
 
   it "embeds YouTube  as iframe" do
     govspeak_md = "$YoutubeVideo(https://www.youtube.com/watch?v=ABCDEFGHIJ)$EndYoutubeVideo"
-    expected_html = %(<iframe width="500" height="281" src="https://www.youtube.com/embed/ABCDEFGHIJ?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.help-for-early-years.education.gov.uk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>\n)
+    expected_html = %(<iframe src="https://www.youtube.com/embed/ABCDEFGHIJ?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.help-for-early-years.education.gov.uk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>\n)
     rendered = GovspeakToHTML.new.translate_markdown(govspeak_md)
     expect(rendered).to eq(expected_html)
   end
 
   it "Youtube Embedding with title" do
     govspeak_md = "$YoutubeVideo[Test title](https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo"
-    expected_html = %(<iframe width="500" height="281" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.help-for-early-years.education.gov.uk" title="Test title" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>\n)
+    expected_html = %(<iframe src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.help-for-early-years.education.gov.uk" title="Test title" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>\n)
     rendered = GovspeakToHTML.new.translate_markdown(govspeak_md)
     expect(rendered).to eq(expected_html)
   end
 
   it "Youtube Embedding without title" do
     govspeak_md = "$YoutubeVideo(https://www.youtube.com/watch?v=EpjSlCJtPLo&list=PL4IuMlmijgAfTwwEiZmMp28Eaf66S3a1R&index=2&t=0s)$EndYoutubeVideo"
-    expected_html = %(<iframe width="500" height="281" src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.help-for-early-years.education.gov.uk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>\n)
+    expected_html = %(<iframe src="https://www.youtube.com/embed/EpjSlCJtPLo?enablejsapi=1&amp;origin=https%3A%2F%2Fwww.help-for-early-years.education.gov.uk" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe>\n)
     rendered = GovspeakToHTML.new.translate_markdown(govspeak_md)
     expect(rendered).to eq(expected_html)
   end


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/HFEYP-49

Wraps Govspeak::Document to add YoutubeVideo

### Changes proposed in this pull request
Adds a GovspeakDecorator about the Govspeak::Document object.  For now, still using GovspeakToHtml as a service, although this functionality could be moved into the Govspeak decorator.

### Guidance to review

Add video using the following markdown:

`$YoutubeVideo[OPTIONAL TITLE](YOUTUBE_URL)$EndYoutubeVideo`
