### PR TITLE
add link to google doc accessibility statement

### DIFF
--- a/app/views/layouts/_footer_content.html.erb
+++ b/app/views/layouts/_footer_content.html.erb
@@ -8,7 +8,7 @@
             <ul class="govuk-footer__inline-list">
             
                 <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="accessibility-statement">
+                <a class="govuk-footer__link" target="_blank" rel="noopener noreferrer" href="https://docs.google.com/document/d/1IhrRh6SAvrx9w_Dci5YxR6yuvSvtXTSbq_5t-cWAmJQ/edit#heading=h.ir2yfp83b7q9">
                     Accessibility
                 </a>
                 </li>


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/jira/software/projects/HFEYP/boards/83?selectedIssue=HFEYP-150

### Changes proposed in this pull request
- Add link to google doc containing placeholder accessibility statement
- Link opens in new tab

### Guidance to review
- Check link opens correctly
