### PR TITLE
Turn Basic Auth on in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ ENV LANG=C.UTF-8 \
     GOVUK_APP_DOMAIN=www.gov.uk \
     GOVUK_WEBSITE_ROOT=https://www.gov.uk \
     SECRET_KEY_BASE=TestKey \
-    IGNORE_SECRETS_FOR_BUILD=1
+    IGNORE_SECRETS_FOR_BUILD=1 \
+    USE_BASIC_AUTH=1
 
 # Add the timezone as it's not configured by default in Alpine
 RUN apk add --update --no-cache tzdata && \


### PR DESCRIPTION
### Context
Tiny PR to turn on Basic Auth on production

### Changes proposed in this pull request
An environment variable, USE_BASIC_AUTH is now set in the production docker file

### Guidance to review

