### PR TITLE
288 using ordinary auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV LANG=C.UTF-8 \
     GOVUK_WEBSITE_ROOT=https://www.gov.uk \
     SECRET_KEY_BASE=TestKey \
     IGNORE_SECRETS_FOR_BUILD=1 \
-    USE_BASIC_AUTH=1
+    AUTH_ON_EVERYTHING=1
 
 # Add the timezone as it's not configured by default in Alpine
 RUN apk add --update --no-cache tzdata && \

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cancel the running docker process and then run `docker-compose down` (for a full
 
 ### Authentication
 Devise is used for the CMS routes.  Basic Auth can be turned on for the whole site by setting 
-and environment variable called USE_BASIC_AUTH.
+and environment variable called AUTH_ON_EVERYTHING.
 
 The ContentController will then use the devise accounts to check the basic auth, but it does
 not log users in.

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,31 +1,9 @@
 class ContentController < ApplicationController
-  before_action :authenticate
-
-  # There is a temporary need to put basic auth around the public pages
-  # but it should be easy to turn off. So, if the env var is set, the
-  # user should have a devise account. This does not log them in via
-  # devise or Warden, it just satisfies Basic Auth
-  def authenticate
-    # rubocop is doing my head in
-    # rubocop:disable Style/NegatedIf
-    if !ENV["USE_BASIC_AUTH"]
-      return true
-    end
-
-    # rubocop:enable Style/NegatedIf
-
-    authenticate_or_request_with_http_basic do |username, password|
-      user = User.find_by_email username
-      if user && BCrypt::Password.new(user.encrypted_password) == password
-        true
-      else
-        false
-      end
-    end
-  end
+  before_action :authenticate_user!, if: proc { ENV["AUTH_ON_EVERYTHING"].nil? }
 
   layout "content"
-  # This is a page whose title and children's titles are rendered in
+
+  # This is a page whose title and children's titles are rendered
   # a block in the landing_page_layout template
   FEATURED_PAGE_TITLE = "Get help to improve your practice".freeze
 

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,5 +1,5 @@
 class ContentController < ApplicationController
-  before_action :authenticate_user!, if: proc { ENV["AUTH_ON_EVERYTHING"].nil? }
+  before_action :authenticate_user!, if: proc { !ENV["AUTH_ON_EVERYTHING"].nil? }
 
   layout "content"
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -11,13 +11,17 @@
 
         <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
           <div class="govuk-form-group">
-            <%= f.label :email, class: "govuk-label", for: "email_address"%><br />
-            <%= f.email_field :email, autofocus: true, ariadescribed_by: "input-email_address" %>
+            <h1 class="govuk-label-wrapper">
+              <%= f.label :email, class: "govuk-label govuk-label--l", for: "email_address"%>
+            </h1>
+            <%= f.email_field :email, autofocus: true, ariadescribed_by: "input-email_address", class: "govuk-input" %>
           </div>
 
           <div class="govuk-form-group">
-            <%= f.label :password, class: "govuk-label", for: "input_password" %><br />
-            <%= f.password_field :password, ariadescribed_by: "input-password" %>
+            <h1 class="govuk-label-wrapper">
+              <%= f.label :password, class: "govuk-label govuk-label--l", for: "input_password" %>
+            </h1>
+            <%= f.password_field :password, ariadescribed_by: "input-password", class: "govuk-input" %>
           </div>
           <br/>
           <% if devise_mapping.rememberable? %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,7 +55,6 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.hosts << "eyfs-dev.london.cloudapps.digital"
-  config.hosts << "903a4bd61281.ngrok.io"
   config.hosts << "cms.lvh.me"
   config.hosts << "ebrett.ngrok.io"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,6 +55,7 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.hosts << "eyfs-dev.london.cloudapps.digital"
+  config.hosts << "903a4bd61281.ngrok.io"
   config.hosts << "cms.lvh.me"
   config.hosts << "ebrett.ngrok.io"
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 require "support/without_detailed_exceptions"
-require "support/auth_helper"
 
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)

--- a/spec/requests/content_request_spec.rb
+++ b/spec/requests/content_request_spec.rb
@@ -1,16 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "Contents", type: :request do
-  include AuthHelper
-
   let(:a_page) do
     parent = FactoryBot.create(:content_page)
     FactoryBot.create(:content_page, parent_id: parent.id)
-  end
-
-  let(:authorization) do
-    user = FactoryBot.create :user
-    http_login(user.email, user.password)
   end
 
   before :all do
@@ -19,13 +12,13 @@ RSpec.describe "Contents", type: :request do
 
   describe "GET /show" do
     it "renders a page" do
-      get a_page.full_path, headers: { "HTTP_AUTHORIZATION" => authorization }
+      get a_page.full_path
       expect(response).to be_successful
     end
 
     it "renders a 404 when the page is not found" do
       without_detailed_exceptions do
-        get a_page.full_path + "rubbish", headers: { "HTTP_AUTHORIZATION" => authorization }
+        get a_page.full_path + "rubbish"
         expect(response).to have_http_status :not_found
       end
     end
@@ -33,7 +26,7 @@ RSpec.describe "Contents", type: :request do
 
   describe "GET /" do
     it "renders the landing page / hub page" do
-      get "/", headers: { "HTTP_AUTHORIZATION" => authorization }
+      get "/"
       expect(response).to be_successful
     end
 
@@ -45,32 +38,26 @@ RSpec.describe "Contents", type: :request do
   end
 
   describe "Temporary authorisation on public site" do
-    # login to http basic auth
-    include AuthHelper
-
-    context "With the environment variable USE_BASIC_AUTH set" do
-      it "shows a basic auth dialog if the user is not already logged in with Basic Auth" do
-        cached_env_var = ENV["USE_BASIC_AUTH"]
-        ENV["USE_BASIC_AUTH"] = "true"
+    context "With the environment variable AUTH_ON_EVERYTHING set" do
+      it "shows an auth dialog if the user is not already logged in" do
+        cached_env_var = ENV["AUTH_ON_EVERYTHING"]
+        ENV["AUTH_ON_EVERYTHING"] = "true"
 
         get "/"
-        expect(response.status).to eq(401)
+        expect(response.status).to eq(302)
 
-        ENV["USE_BASIC_AUTH"] = cached_env_var
+        ENV["AUTH_ON_EVERYTHING"] = cached_env_var
       end
 
-      # This test needs to pass before the PR is accepted
-      it "does not show a basic auth dialog if the user is already logged in with Basic Auth" do
-        cached_env_var = ENV["USE_BASIC_AUTH"] = "true"
+      it "does not show an auth dialog if the user is already logged" do
+        cached_env_var = ENV["AUTH_ON_EVERYTHING"] = "true"
+        sign_in FactoryBot.create(:user)
 
-        user = FactoryBot.create :user
-        authorization = http_login user.email, user.password
-
-        get "/", headers: { "HTTP_AUTHORIZATION" => authorization }
+        get "/"
 
         expect(response.status).to eq(200)
 
-        ENV["USE_BASIC_AUTH"] = cached_env_var
+        ENV["AUTH_ON_EVERYTHING"] = cached_env_var
       end
     end
   end

--- a/spec/support/auth_helper.rb
+++ b/spec/support/auth_helper.rb
@@ -1,5 +1,0 @@
-module AuthHelper
-  def http_login(user, password)
-    ActionController::HttpAuthentication::Basic.encode_credentials(user, password)
-  end
-end


### PR DESCRIPTION
### Context
288 - adding auth for the 'service users', the first people to see the site, before its open to the public

Another ticket will stop users editing content https://dfedigital.atlassian.net/browse/HFEYP-320

### Changes proposed in this pull request
Replace the Basic Auth login form with the ordinary one

### Guidance to review
If the environment variable AUTH_ON_EVERYTHING is set, people will have to log in to see any content at all

