### PR TITLE
Add content security policy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem "htmlentities", "4.3.4"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.1.0", require: false
 
+gem "govuk_app_config"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,6 +458,7 @@ DEPENDENCIES
   faker
   foreman
   govspeak
+  govuk_app_config
   htmlentities (= 4.3.4)
   listen (>= 3.0.5, < 3.6)
   pg (>= 0.18, < 2.0)

--- a/config/initializers/csp.rb
+++ b/config/initializers/csp.rb
@@ -1,0 +1,1 @@
+GovukContentSecurityPolicy.configure


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/HFEYP-236

### Changes proposed in this pull request

Using the govuk_app_config gem and the default configuration

### Guidance to review

```
❯ curl -s -D - http://localhost:3000/communication-and-language -o /dev/null
HTTP/1.1 200 OK
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Permitted-Cross-Domain-Policies: none
Referrer-Policy: strict-origin-when-cross-origin
Content-Type: text/html; charset=utf-8
Vary: Accept,Accept-Encoding
ETag: W/"0851e9cbf4f978aa6a421fca9d13fc9c"
Cache-Control: max-age=0, private, must-revalidate
Content-Security-Policy: default-src https: 'self' *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk; img-src 'self' data: *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com assets.digital.cabinet-office.gov.uk lux.speedcurve.com; script-src 'self' *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com www.gstatic.com www.signin.service.gov.uk *.ytimg.com www.youtube.com www.youtube-nocookie.com hmrc-uk.digital.nuance.com 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk www.gstatic.com 'unsafe-inline'; font-src 'self' *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk data:; connect-src 'self' *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com www.tax.service.gov.uk hmrc-uk.digital.nuance.com gov.klick2contact.com www.signin.service.gov.uk; object-src 'none'; frame-src 'self' *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk www.youtube.com www.youtube-nocookie.com
Set-Cookie: _help_for_early_years_providers_session=4QJ0l5th7CmdxvlBLO1MhiyaBUIeotNNrC95SAJz06kbBmfIlHW46ua8aLOvLmIgNoaEtILrFImZRCFfq9BuoUIsf%2FELXjgwdH0A6iGsYZLNMYENd%2Bu1yVgg6oAzHKutD2BKsXPuCUvMVKatfN%2F2BtJ6DsUvIUrgfVsKFv7riTtLBxCzsUx2I46b32eORmduRw7LsILgJ9Rs7YTyumJFEXsqgaA58lGQ%2F7A%2B5VMv6XrtIVuC%2BjTj%2FI7llgwlnYpEpucPMiT0tNYLw2X%2FnSNufQlQxGKWVQdPadrKFqfMY6UVQCq2YquPyDu8pATd85o%3D--e6XhjTSrRKrRk625--iUqyGthlG%2FARdxmzvImmMA%3D%3D; path=/; HttpOnly
X-Request-Id: 807d8632-fb58-439d-bf2f-7b52774c962f
X-Runtime: 3.674310
Transfer-Encoding: chunked
```
