### PR TITLE
Only set the env var AUTH_ON_EVERYTHING on production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,6 +113,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_USERNAME_PROD }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_PASSWORD_PROD }}
+          AUTH_ON_EVERYTHING: true
         run: |
           export TF_VAR_paas_app_docker_image=${{ env.DOCKER_IMAGE }}
           cd terraform/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ ENV LANG=C.UTF-8 \
     GOVUK_APP_DOMAIN=www.gov.uk \
     GOVUK_WEBSITE_ROOT=https://www.gov.uk \
     SECRET_KEY_BASE=TestKey \
-    IGNORE_SECRETS_FOR_BUILD=1 \
-    AUTH_ON_EVERYTHING=true
+    IGNORE_SECRETS_FOR_BUILD=1
 
 # Add the timezone as it's not configured by default in Alpine
 RUN apk add --update --no-cache tzdata && \


### PR DESCRIPTION
### Context
Because AUTH_ON_EVERYTHING is currently set in the Dockerfile,  all environments require login, and the non cms environments prevent login !  So nobody can see the content on https://eyfs-dev.london.cloudapps.digital/,  https://eyfs-test.london.cloudapps.digital/ and https://eyfs-prod.london.cloudapps.digital/.  Although this is what we want on production, it is not what we want on test or dev.

### Changes proposed in this pull request
AUTH_ON_EVERYTHING is no longer set for all environments
It is selectively set just for prod

### Guidance to review
Check that the environments mentioned above do not restrict access to the content
Check that the https://eyfs-prod.london.cloudapps.digital/ does !
