### PR TITLE
Disable X-XSS-Protection

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,11 @@ module GovukRailsBoilerplate
 
     config.exceptions_app = routes
 
+    # disable client-side XSS Auditors, as they have been removed from most
+    # modern browsers because they can cause additional vulnerabilities
+    # (see https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#x-xss-protection-header)
+    config.action_dispatch.default_headers['X-XSS-Protection'] = "0"
+
     config.middleware.use Rack::Deflater
   end
 end


### PR DESCRIPTION
### Context

16/04 Medium: Multiple Security headers were found to be missing/misconfigured within responses received from tested host

https://dfedigital.atlassian.net/browse/HFEYP-236

### Changes proposed in this pull request

disable client-side XSS Auditors, as they have been removed from most modern browsers because they can cause additional vulnerabilities
(see https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#x-xss-protection-header)

### Guidance to review

As with content security policy, headers can be viewed via curl:

```
❯ curl -s -D - http://localhost:3000/communication-and-language -o /dev/null
HTTP/1.1 200 OK
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 0
```