### PR TITLE
Rails.logger.silence was missing in production

### DIFF
--- a/app/controllers/content_pages_controller.rb
+++ b/app/controllers/content_pages_controller.rb
@@ -55,11 +55,9 @@ class ContentPagesController < ApplicationController
 
   # POST of preview, returns html
   def preview
-    Rails.logger.silence do
-      html = GovspeakToHTML.new.translate_markdown(params["markdown"])
+    html = GovspeakToHTML.new.translate_markdown(params["markdown"])
 
-      render json: { html: html }
-    end
+    render json: { html: html }
   end
 
 private


### PR DESCRIPTION
### Context
For a reason unknown yet, the method Rails.logging.silence is no longer available on production

So the live preview requests fail with a 500 error

It works fine in development

### Changes proposed in this pull request
Remove Rails.logging.silence for now

### Guidance to review

