### PR TITLE
Update content security policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,19 +4,66 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-#   policy.script_src  :self, :https
-#   policy.style_src   :self, :https
-#   # If you are using webpack-dev-server then specify webpack-dev-server host
-#   policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035" if Rails.env.development?
+# See https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP for more CSP info.
+#
+# The resulting policy should be checked with:
+#
+# - https://csp-evaluator.withgoogle.com
+# - https://cspvalidator.org
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+GOVUK_DOMAINS = [
+  "*.education.gov.uk",
+  "*.london.cloudapps.digital"
+].uniq.freeze
+
+S3_DOMAINS = [
+  "*.s3.eu-west-1.amazonaws.com",
+  "*.s3.eu-west-2.amazonaws.com"
+].uniq.freeze
+
+GOOGLE_ANALYTICS_DOMAINS = %w[www.google-analytics.com
+                              ssl.google-analytics.com
+                              stats.g.doubleclick.net
+                              www.googletagmanager.com].freeze
+
+GOOGLE_STATIC_DOMAINS = %w[www.gstatic.com].freeze
+
+Rails.application.config.content_security_policy do |policy|
+  policy.default_src :self, :https, *GOVUK_DOMAINS
+  policy.font_src    :self, :https, *GOVUK_DOMAINS, :data
+  policy.img_src     :self,
+                     *GOVUK_DOMAINS,
+                     *S3_DOMAINS,
+                     *GOOGLE_ANALYTICS_DOMAINS, # Tracking pixels
+                     :data # Base64 encoded images
+  policy.object_src  :none
+  policy.script_src  :self,
+                     *GOVUK_DOMAINS,
+                     *GOOGLE_ANALYTICS_DOMAINS,
+                     *GOOGLE_STATIC_DOMAINS,
+                     # Allow YouTube Embeds (Govspeak turns YouTube links into embeds)
+                     "*.ytimg.com",
+                     "www.youtube.com",
+                     "www.youtube-nocookie.com",
+                     # Allow all inline scripts until we can conclusively
+                     # document all the inline scripts we use,
+                     # and there's a better way to filter out junk reports
+                     :unsafe_inline
+  policy.style_src   :self, *GOVUK_DOMAINS, *GOOGLE_STATIC_DOMAINS
+  if Rails.env.development?
+    policy.connect_src :self,
+                       :https,
+                       *GOVUK_DOMAINS,
+                       *GOOGLE_ANALYTICS_DOMAINS,
+                       "http://localhost:3035",
+                       "ws://localhost:3035"
+  else
+    policy.connect_src :self,
+                       :https,
+                       *GOVUK_DOMAINS,
+                       *GOOGLE_ANALYTICS_DOMAINS
+  end
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,12 +13,12 @@
 
 GOVUK_DOMAINS = [
   "*.education.gov.uk",
-  "*.london.cloudapps.digital"
+  "*.london.cloudapps.digital",
 ].uniq.freeze
 
 S3_DOMAINS = [
   "*.s3.eu-west-1.amazonaws.com",
-  "*.s3.eu-west-2.amazonaws.com"
+  "*.s3.eu-west-2.amazonaws.com",
 ].uniq.freeze
 
 GOOGLE_ANALYTICS_DOMAINS = %w[www.google-analytics.com


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/HFEYP-236

### Changes proposed in this pull request
No longer using govuk gem (turns out it's built in to Rails now)

Cherry picked the Google and YouTube bits from the gem and added
DfE specific domains and S3 Domains

### Guidance to review

Test by adding images and using those images in the same environment.

"Cross environment" image posting should work, but should be
discouraged.

If images from any other domains are needed, these domains will need to
be added.
