### PR TITLE
246 limit upload rate

### DIFF
--- a/app/controllers/content_assets_controller.rb
+++ b/app/controllers/content_assets_controller.rb
@@ -59,7 +59,7 @@ class ContentAssetsController < ApplicationController
 private
 
   def upload_rate_limit_exceeded?
-    ContentAsset.where(updated_at: 30.seconds.ago..Time.now).count > 0
+    ContentAsset.where(updated_at: 30.seconds.ago..Time.zone.now).count.positive?
   end
 
   # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/content_assets_controller.rb
+++ b/app/controllers/content_assets_controller.rb
@@ -27,7 +27,10 @@ class ContentAssetsController < ApplicationController
     @content_asset = ContentAsset.new(content_asset_params)
 
     authorize @content_asset, :create?
-    if @content_asset.save
+
+    if upload_rate_limit_exceeded?
+      redirect_to content_assets_url, notice: "Only one upload is allowed in each 30 seconds, please wait"
+    elsif @content_asset.save
       redirect_to @content_asset, notice: "Content asset was successfully created."
     else
       render :new
@@ -54,6 +57,10 @@ class ContentAssetsController < ApplicationController
   end
 
 private
+
+  def upload_rate_limit_exceeded?
+    ContentAsset.where(updated_at: 30.seconds.ago..Time.now).count > 0
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_content_asset

--- a/app/models/content_asset.rb
+++ b/app/models/content_asset.rb
@@ -1,4 +1,6 @@
 class ContentAsset < ApplicationRecord
+  audited
+
   VALID_FILE_EXTENSIONS = %w[.pdf .doc .docx .xls .xlsx .jpeg .jpg .png].freeze
   VALID_CONTENT_TYPE = %w[
     image/jpeg

--- a/app/views/content_assets/_form.html.erb
+++ b/app/views/content_assets/_form.html.erb
@@ -23,8 +23,8 @@
 <div class="govuk-grid-column-one-half">
   <%= form.submit('Submit', :class => "govuk-button") %>
 </div>
-</div>   
+</div>
 
 <% end %>
 
-<%= link_to 'GOV.UK image upload guidelines', 'https://design-system.service.gov.uk/styles/images/', target: "_blank" %> | 
+<%= link_to 'GOV.UK image upload guidelines', 'https://design-system.service.gov.uk/styles/images/', target: "_blank" %> |

--- a/app/views/content_assets/index.html.erb
+++ b/app/views/content_assets/index.html.erb
@@ -1,6 +1,10 @@
-<p id="notice"><%= notice %></p>
+<div class="govuk-error-message" role="alert" aria-labelledby="error-summary-heading">
+  <span id="notice"><%= notice %></span>
+</div>
 
 <h1  class="govuk-heading-l">Assets</h1>
+
+<%= link_to 'Add Asset', new_content_asset_path, :class => "govuk-link" %>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -13,11 +13,3 @@ FactoryBot.define do
     role { "reader" }
   end
 end
-
-FactoryBot.define do
-  factory :content_asset do
-    title { "Title" }
-    alt_text { "Sample alt text" }
-    asset_file { Rack::Test::UploadedFile.new("spec/fixtures/sample.jpeg", "image/jpeg") }
-  end
-end

--- a/spec/factories/content_assets.rb
+++ b/spec/factories/content_assets.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :content_asset do
+    title { Faker::Lorem.sentence(word_count: 4).to_s }
+    alt_text { Faker::Lorem.sentence(word_count: 4).to_s }
+    asset_file { Rack::Test::UploadedFile.new("spec/fixtures/sample.jpeg", "image/jpeg") }
+  end
+end

--- a/spec/requests/content_assets_spec.rb
+++ b/spec/requests/content_assets_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "/content_assets", type: :request do
   # ContentAsset. As you add validations to ContentAsset, be sure to
   # adjust the attributes here as well.
   let(:valid_attributes) do
-    skip("Add a hash of attributes valid for your model")
+    FactoryBot.attributes_for(:content_asset)
   end
 
   let(:invalid_attributes) do
@@ -25,6 +25,8 @@ RSpec.describe "/content_assets", type: :request do
 
   describe "GET /index" do
     it "renders a successful response" do
+      sign_in FactoryBot.create(:user)
+
       ContentAsset.create! valid_attributes
       get content_assets_url
       expect(response).to be_successful
@@ -33,6 +35,8 @@ RSpec.describe "/content_assets", type: :request do
 
   describe "GET /show" do
     it "renders a successful response" do
+      sign_in FactoryBot.create(:user)
+
       content_asset = ContentAsset.create! valid_attributes
       get content_asset_url(content_asset)
       expect(response).to be_successful
@@ -50,6 +54,8 @@ RSpec.describe "/content_assets", type: :request do
 
   describe "GET /edit" do
     it "render a successful response" do
+      sign_in FactoryBot.create(:user)
+
       content_asset = ContentAsset.create! valid_attributes
       get edit_content_asset_url(content_asset)
       expect(response).to be_successful
@@ -59,12 +65,16 @@ RSpec.describe "/content_assets", type: :request do
   describe "POST /create" do
     context "with valid parameters" do
       it "creates a new ContentAsset" do
+        sign_in FactoryBot.create(:user)
+
         expect {
           post content_assets_url, params: { content_asset: valid_attributes }
         }.to change(ContentAsset, :count).by(1)
       end
 
       it "redirects to the created content_asset" do
+        sign_in FactoryBot.create(:user)
+
         post content_assets_url, params: { content_asset: valid_attributes }
         expect(response).to redirect_to(content_asset_url(ContentAsset.last))
       end
@@ -72,6 +82,8 @@ RSpec.describe "/content_assets", type: :request do
 
     context "with invalid parameters" do
       it "does not create a new ContentAsset" do
+        sign_in FactoryBot.create(:user)
+
         expect {
           post content_assets_url, params: { content_asset: invalid_attributes }
         }.to change(ContentAsset, :count).by(0)
@@ -80,6 +92,27 @@ RSpec.describe "/content_assets", type: :request do
       it "renders a successful response (i.e. to display the 'new' template)" do
         post content_assets_url, params: { content_asset: invalid_attributes }
         expect(response).to be_successful
+      end
+    end
+
+    context "when the rate limit is exceeded" do
+      it "will not create two ContentAssets within 30 seconds of each other" do
+        sign_in FactoryBot.create(:user)
+
+        expect {
+          post content_assets_url, params: { content_asset: valid_attributes }
+
+          other_valid_attributes = FactoryBot.attributes_for(:content_asset)
+          post content_assets_url, params: { content_asset: other_valid_attributes }
+        }.to change(ContentAsset, :count).by(1)
+        # ie change by only 1, not 2, I could not get to_not working with change
+      end
+
+      it "redirects to the created content_asset" do
+        sign_in FactoryBot.create(:user)
+
+        post content_assets_url, params: { content_asset: valid_attributes }
+        expect(response).to redirect_to(content_asset_url(ContentAsset.last))
       end
     end
   end
@@ -116,6 +149,8 @@ RSpec.describe "/content_assets", type: :request do
 
   describe "DELETE /destroy" do
     it "destroys the requested content_asset" do
+      sign_in FactoryBot.create(:user)
+
       content_asset = ContentAsset.create! valid_attributes
       expect {
         delete content_asset_url(content_asset)
@@ -123,6 +158,8 @@ RSpec.describe "/content_assets", type: :request do
     end
 
     it "redirects to the content_assets list" do
+      sign_in FactoryBot.create(:user)
+
       content_asset = ContentAsset.create! valid_attributes
       delete content_asset_url(content_asset)
       expect(response).to redirect_to(content_assets_url)


### PR DESCRIPTION
### Context
Prevent the content editor people from launching a Denial of Service attack on the site by uploading many images at once (!)

https://dfedigital.atlassian.net/browse/HFEYP-246

### Changes proposed in this pull request
The ContentAssets are now auditable, so there is an easy way for the ContentAssetController to check how long it's been since the last one was created.  If its within 30 seconds, the controller redirects to the index page with a notice.

### Guidance to review
Try to create two new assets within 30 seconds
