### PR TITLE
Fix cookies page related bugs

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -2,12 +2,8 @@ class SettingsController < ApplicationController
   layout "settings"
 
   def create
-    if params.key?(:track_google_analytics)
-      set_cookie_pref(params[:track_google_analytics])
-      redirect_to params[:return_url]
-    else
-      raise "Missing parameters"
-    end
+    set_cookie_pref(track_google_analytics)
+    redirect_to params[:return_url]
   end
 
   def show
@@ -15,6 +11,10 @@ class SettingsController < ApplicationController
   end
 
 private
+
+  def track_google_analytics
+    params.fetch(:track_google_analytics, "No")
+  end
 
   def set_cookie_pref(cookie_value)
     cookies[:track_google_analytics] = { value: cookie_value, expires: 6.months.from_now }

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -9,7 +9,7 @@
         </div>
         <br/>
 
-        <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+        <%= form_for(resource, as: resource_name, url: session_path(resource_name), autocomplete: "off") do |f| %>
           <div class="govuk-form-group">
             <h1 class="govuk-label-wrapper">
               <%= f.label :email, class: "govuk-label govuk-label--l", for: "email_address"%>

--- a/app/views/layouts/_footer_content.html.erb
+++ b/app/views/layouts/_footer_content.html.erb
@@ -14,7 +14,7 @@
                 </li>
             
                 <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="settings/cookie-policy">
+                <a class="govuk-footer__link" href="/settings/cookie-policy">
                     Cookies
                 </a>
                 </li>


### PR DESCRIPTION
### Context
Fix two small cookies page related bugs, and add autocomplete to see if that helps with 336

https://dfedigital.atlassian.net/browse/HFEYP-334
https://dfedigital.atlassian.net/browse/HFEYP-339
https://dfedigital.atlassian.net/browse/HFEYP-336

### Changes proposed in this pull request
* use a default ("No") if no choice is made for tracking
* address for cookies page in footer not relative
* turn off autocomplete on sign in form

### Guidance to review

Clear cookies and go to landing page -- view cookies and then submit without making a selection.  Default selection of "no" is made.

Check cookies link in footer of child pages

See if browser uses autofill if autocomplete is turned off