### PR TITLE
Turn off AUTH_ON_EVERYTHING - for load testing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,13 +113,12 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}
           TF_VAR_paas_user: ${{ secrets.GOVPAAS_USERNAME_PROD }}
           TF_VAR_paas_password: ${{ secrets.GOVPAAS_PASSWORD_PROD }}
-          AUTH_ON_EVERYTHING: 'true'
         run: |
           export TF_VAR_paas_app_docker_image=${{ env.DOCKER_IMAGE }}
           cd terraform/app
           terraform init -reconfigure -input=false -backend-config="bucket=${{secrets.AWS_BUCKET_PROD}}"
           terraform plan -var-file ../workspace-variables/prod.tfvars
-          terraform apply -input=false -auto-approve -var-file ../workspace-variables/prod.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_PROD}}", "AWS_ACCESS_KEY_ID": "${{secrets.AWS_ACCESS_KEY_ID_PROD}}", "AWS_SECRET_ACCESS_KEY": "${{secrets.AWS_SECRET_ACCESS_KEY_PROD}}", "AWS_REGION": "${{secrets.AWS_REGION}}", "AWS_BUCKET": "${{secrets.AWS_BUCKET_PROD}}", "BASIC_AUTH_USER": "${{secrets.BASIC_AUTH_USER}}", "BASIC_AUTH_PASSWORD": "${{secrets.BASIC_AUTH_PASSWORD}}", "AUTH_ON_EVERYTHING": "true"}'
+          terraform apply -input=false -auto-approve -var-file ../workspace-variables/prod.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_PROD}}", "AWS_ACCESS_KEY_ID": "${{secrets.AWS_ACCESS_KEY_ID_PROD}}", "AWS_SECRET_ACCESS_KEY": "${{secrets.AWS_SECRET_ACCESS_KEY_PROD}}", "AWS_REGION": "${{secrets.AWS_REGION}}", "AWS_BUCKET": "${{secrets.AWS_BUCKET_PROD}}", "BASIC_AUTH_USER": "${{secrets.BASIC_AUTH_USER}}", "BASIC_AUTH_PASSWORD": "${{secrets.BASIC_AUTH_PASSWORD}}"}'
 
       - name: Install CF CLI on Prod
         uses: DFE-Digital/github-actions/setup-cf-cli@master


### PR DESCRIPTION
### Context
For load testing, we need to let the callers get to the pages without needing to log in

### Changes proposed in this pull request
Temporarily remove the environment variable called AUTH_ON_EVERYTHING

### Guidance to review
Should not have any effect on dev or test

