### PR TITLE
Add disclaimer page, small refactor, fix email on accessibility, remove rememberable

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,0 +1,5 @@
+class StaticPagesController < ApplicationController
+  def accessibility_statement; end
+
+  def disclaimer; end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,6 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable,
-         :rememberable,
          :validatable,
          :timeoutable,
          :lockable

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -9,7 +9,7 @@
         </div>
         <br/>
 
-        <%= form_for(resource, as: resource_name, url: session_path(resource_name), autocomplete: "off") do |f| %>
+        <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { autocomplete: "off" }) do |f| %>
           <div class="govuk-form-group">
             <h1 class="govuk-label-wrapper">
               <%= f.label :email, class: "govuk-label govuk-label--l", for: "email_address"%>

--- a/app/views/layouts/_footer_content.html.erb
+++ b/app/views/layouts/_footer_content.html.erb
@@ -25,6 +25,12 @@
                 </a>
                 </li>
             
+                <li class="govuk-footer__inline-list-item">
+                <a class="govuk-footer__link" href="/disclaimer">
+                    Disclaimer
+                </a>
+                </li>
+            
             </ul>
         
         

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,18 +55,7 @@
 
 <main role="main" class="govuk-width-container">
   <div class="govuk-main-wrapper" id="main-content">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Accessibility statement for the Help for early years providers service</h1>
-        <p class="govuk-body">A full accessibility statement will appear on this page before the Help for early years providers website is made available to the public.</p>
-        <p class="govuk-body">The page will cover:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>the efforts we have made to comply with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018</li>
-          <li>how this website meets the Web Content Accessibility Guidelines version 2.1 AA standard</li>
-        </ul>
-        <p class="govuk-body">If you have any feedback on the accessibility of this website, please contact <a class="govuk-link" href="mailto:help_for_early_years_providers@digital.education.gov.uk">help_for_early_years_providers@digital.education.gov.uk</p>
-      </div>
-    </div>
+    <%= yield %>
   </div>
 </main>
 

--- a/app/views/static_pages/accessibility_statement.html.erb
+++ b/app/views/static_pages/accessibility_statement.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Accessibility statement for the Help for early years providers service</h1>
+    <p class="govuk-body">A full accessibility statement will appear on this page before the Help for early years providers website is made available to the public.</p>
+    <p class="govuk-body">The page will cover:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the efforts we have made to comply with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018</li>
+      <li>how this website meets the Web Content Accessibility Guidelines version 2.1 AA standard</li>
+    </ul>
+    <p class="govuk-body">If you have any feedback on the accessibility of this website, please contact <a class="govuk-link email" href="mailto:help_for_early_years_providers@digital.education.gov.uk">help_for_early_years_providers@digital.education.gov.uk</p>
+  </div>
+</div>

--- a/app/views/static_pages/disclaimer.html.erb
+++ b/app/views/static_pages/disclaimer.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"> Disclaimer </h1>
+    <h2 class="govuk-heading"> Linking from help for early years providers </h2>
+    <p class="govuk-body"> Help for early years providers links to websites that are managed by other government departments and agencies, service providers or other organisations. This includes links in the ‘other activities’ sections of our pages. We do not have any control over the content on these websites. </p>
+    <p class="govuk-body"> We’re not responsible for: </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li> the protection of any information you give to these websites </li>
+      <li> any loss or damage that may come from your use of these websites, or any other websites they link to </li>
+    </ul>
+    <p class="govuk-body"> Linking to a website does not constitute an endorsement of that website by the Department for Education or any other government department or agency. </p>
+    <p class="govuk-body"> You do not have to use the external resources we link to. The lists of external resources are not exhaustive. </p>
+    <p class="govuk-body"> You agree to release us from any claims or disputes that may come from using these websites. </p>
+    <p class="govuk-body"> You should read all terms and conditions, privacy policies and end user licences that relate to these websites before you use them. </p>
+    <p class="govuk-body"> Should you have a concern about the content of a site we link to please email <a class="govuk-link email" href="mailto:help_for_early_years_providers@digital.education.gov.uk">help_for_early_years_providers@digital.education.gov.uk</p>
+  </div>
+</div>
+
+
+
+

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -25,3 +25,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "_cms.scss";
 @import "_links.scss";
 @import "_flash.scss";
+
+.email {
+  word-wrap: break-word;
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,6 @@ Rails.application.routes.draw do
 
   resources :settings, only: %i[show create]
 
-  get "/accessibility-statement", to: "accessibility_page#show"
-
   constraints CmsRouteConstraint.new do
     devise_for :users
     devise_scope :user do
@@ -23,6 +21,10 @@ Rails.application.routes.draw do
       #  This is not a resource route
       post "preview_markdown", to: "content_pages#preview"
     end
+  end
+
+  %w[accessibility-statement disclaimer].each do |static_page|
+    get "/#{static_page}", to: "static_pages##{static_page.underscore}"
   end
 
   get "/:section/:slug", to: "content#show"

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "renders a static page" do
+  it "accessibility-statement" do
+    get "/accessibility-statement"
+    expect(response).to be_successful
+  end
+
+  it "disclaimer" do
+    get "/disclaimer"
+    expect(response).to be_successful
+  end
+end


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/HFEYP-217
https://dfedigital.atlassian.net/browse/HFEYP-335
https://dfedigital.atlassian.net/browse/HFEYP-338
https://dfedigital.atlassian.net/browse/HFEYP-336

### Changes proposed in this pull request
  * refactor accessibility statement to be served from statics page
  controller
  * add disclaimer as a second static page
  * updatet footer link
  * retry autocomplete off on sign in page (wrap in html)

Also, remove `rememberable` from login

### Guidance to review

