### PR TITLE
Try to avoid signing for images - make them public

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,1 @@
+Rails.application.config.active_storage.resolve_model_to_route = :rails_storage_proxy

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,4 +13,7 @@ amazon:
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region: <%= ENV['AWS_REGION'] %>
   bucket: <%= ENV['AWS_BUCKET'] %>
+  upload:
+  cache_control: 'max-age=86400, private'
+  public-read: true
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -13,7 +13,6 @@ amazon:
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region: <%= ENV['AWS_REGION'] %>
   bucket: <%= ENV['AWS_BUCKET'] %>
+  public-read: true
   upload:
-    cache_control: 'max-age=86400, private'
-    public-read: true
-
+    cache_control: 'private, max-age=31536000'

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -14,6 +14,6 @@ amazon:
   region: <%= ENV['AWS_REGION'] %>
   bucket: <%= ENV['AWS_BUCKET'] %>
   upload:
-  cache_control: 'max-age=86400, private'
-  public-read: true
+    cache_control: 'max-age=86400, private'
+    public-read: true
 


### PR DESCRIPTION
### Context
Trying to speed up the delivery of images.  The S3 bucket needs to be public, but ActiveStorage also needs this setting to make it work

### Changes proposed in this pull request

### Guidance to review

