### PR TITLE
Http headers for caching

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,11 +1,11 @@
 class ContentController < ApplicationController
   before_action :authenticate_user!, if: proc { !ENV["AUTH_ON_EVERYTHING"].nil? }
-  before_action :set_cache_headers
+  after_action :set_cache_headers
 
   def set_cache_headers
     response.headers["Cache-Control"] = "max-age=3600, public"
   end
-
+  
   layout "content"
 
   # This is a page whose title and children's titles are rendered

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,5 +1,10 @@
 class ContentController < ApplicationController
   before_action :authenticate_user!, if: proc { !ENV["AUTH_ON_EVERYTHING"].nil? }
+  before_action :set_cache_headers
+
+  def set_cache_headers
+    response.headers["Cache-Control"] = "max-age=3600, public"
+  end
 
   layout "content"
 

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -5,7 +5,7 @@ class ContentController < ApplicationController
   def set_cache_headers
     response.headers["Cache-Control"] = "max-age=3600, public"
   end
-  
+
   layout "content"
 
   # This is a page whose title and children's titles are rendered

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -2,6 +2,7 @@
 <html lang="en" class="govuk-template">
 <head>
   <meta name="robots" content="noindex, nofollow">
+  <meta name="Cache-Control" content="max-age=3500, public">
   <title>Help for early years providers</title>
   <%= render 'layouts/google_analytics_header' if cookies[:track_google_analytics] == 'Yes' %>
   <%= csrf_meta_tags %>

--- a/app/views/layouts/landing_page_layout.html.erb
+++ b/app/views/layouts/landing_page_layout.html.erb
@@ -6,6 +6,7 @@
     Help for early years providers
   </title>
   <%= render 'layouts/google_analytics_header' if cookies[:track_google_analytics] == 'Yes' %>
+  <meta Cache-Control="max-age=3500, public">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/spec/requests/content_request_spec.rb
+++ b/spec/requests/content_request_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe "Contents", type: :request do
       expect(response).to be_successful
     end
 
+    it "renders the content pages with HTTP headers to allow caching" do
+      get "/"
+      expect(response.headers["Cache-Control"]).to eq("max-age=3600, public")
+    end
+
     xit "renders the desktop menu of content pages, two levels, in correct order" do
     end
 


### PR DESCRIPTION
### Context
The aim is to have these headers appear in content pages, as hints to Cloud Front to cache them and not treat them as dynamic

meta name="Cache-Control" content="max-age=3500, public"

### Changes proposed in this pull request
I did it both in the view layouts and in the controllers

The headers set in the layouts appear in the rendered pages
The headers set in the controller appear in the rspec

### Guidance to review
Check that these headers appear on the content pages, but not in the CMS pages
