### PR TITLE
Update for collapsed/expanded to be used by screenreader

### DIFF
--- a/app/views/layouts/_mobile_menu.html.erb
+++ b/app/views/layouts/_mobile_menu.html.erb
@@ -1,17 +1,23 @@
 <nav class="app-subnav--mobile app-mobile-nav js-app-mobile-nav">
-  <% ContentPage.top_level.order_by_position.each do |top_level_page| %>
-    <div class="learning-section-mobile-nav app-mobile-nav-subnav-toggler">
-      <%= link_to(raw('<h4 class="app-subnav__theme ">' + top_level_page.title + '</h4>'), path_for_this_page(top_level_page), class: "govuk-link app-subnav__link govuk-link--no-visited-state top-level-link") %>
-      <ul class="app-mobile-nav__list app-mobile-subnav-section app-mobile-nav__subnav">
-        <li class="app-mobile-nav__subnav-item <%= is_current?(top_level_page) ? 'app-mobile-nav__subnav-item--current' : '' %>">
-          <%= link_to('Overview', path_for_this_page(top_level_page), aria: {label: "#{top_level_page.title} Overview"}, class: "govuk-link app-subnav__link govuk-link--no-visited-state") %>
-        </li>
-        <% top_level_page.children.order_by_position.each do |child| %>
-          <li class="app-mobile-nav__subnav-item <%= is_current?(child) ? 'app-mobile-nav__subnav-item--current' : '' %>">
-            <%= link_to(child.title, path_for_this_page(child), class: "govuk-link app-subnav__link govuk-link--no-visited-state") %>
+  <ul class="app-mobile-nav__list" aria-label="Navigation menu">
+    <% ContentPage.top_level.order_by_position.each do |top_level_page| %>
+      <li>
+        <div class="learning-section-mobile-nav app-mobile-nav-subnav-toggler">
+          <%= link_to(raw('<h4 class="app-subnav__theme ">' + top_level_page.title + '</h4>'), path_for_this_page(top_level_page), class: "govuk-link app-subnav__link govuk-link--no-visited-state top-level-link") %>
+        </div>
+        <ul class="app-mobile-nav__list app-mobile-subnav-section app-mobile-nav__subnav <%= is_current?(top_level_page) ? 'app-mobile-nav__subnav--active' : '' %>">
+          <li class="app-mobile-nav__subnav-item <%= is_current?(top_level_page) ? 'app-mobile-nav__subnav-item--current' : '' %>">
+            <%= link_to('Overview', path_for_this_page(top_level_page), aria: {label: "#{top_level_page.title} Overview"}, class: "govuk-link app-subnav__link govuk-link--no-visited-state") %>
           </li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+          <% top_level_page.children.order_by_position.each do |child| %>
+            <ul class="app-mobile-nav__list">
+              <li class="app-mobile-nav__subnav-item <%= is_current?(child) ? 'app-mobile-nav__subnav-item--current' : '' %>">
+                <%= link_to(child.title, path_for_this_page(child), class: "govuk-link app-subnav__link govuk-link--no-visited-state") %>
+              </li>
+            </ul>
+          <% end %>
+        </ul>
+      </li>
+    <% end %>
+  </ul>
 </nav>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -47,7 +47,7 @@
         </span>
       </a>
       <div role="tablist" class="app-header-mobile-nav-toggler-wrapper">
-        <button role="tab" aria-controls="mobile-menu-nav" id="app-mobile-nav-toggler" type="button" class="govuk-js-header-toggle govuk-button eyfs-menu-button--border app-header-mobile-nav-toggler" aria-label="Show or hide Top Level Navigation" aria-expanded="false">Menu</button>
+        <button role="tab" aria-controls="mobile-menu-nav" id="app-mobile-nav-toggler" type="button" class="govuk-js-header-toggle govuk-button eyfs-menu-button--border app-header-mobile-nav-toggler js-app-mobile-nav-toggler" aria-label="Show or hide Top Level Navigation" aria-expanded="false">Menu</button>
       </div>
     </div>
     <div class="govuk-header__content">
@@ -59,9 +59,9 @@
   </div>
   </header>
   
-  <nav class="govuk-width-container" role="navigation" id="mobile-menu-nav" aria-label="Mobile menu navigation">
+  <div class="govuk-width-container" role="navigation" id="mobile-menu-nav" aria-label="Mobile menu navigation">
     <%= render 'layouts/mobile_menu' %>
-  </nav>
+  </div>
 
   <aside class="govuk-width-container" role="complementary">
     <%= render 'layouts/phase_banner' %>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -18,29 +18,6 @@ $(document).ready(function() {
 
   //----- mobile nav -----//
 
-  //toggle menu button arrow
-  $( ".govuk-js-header-toggle" ).click(function() {
-    $( ".app-header-mobile-nav-toggler" ).toggleClass('app-header-mobile-nav-toggler--active');
-  });
-
-  //2nd level nav stays visible
-  $('.app-mobile-nav__subnav-item--current').parent().show();
-
-  //show mobile nav when clicking hamburger
-  $( ".govuk-js-header-toggle" ).click(function() {
-    $( ".app-subnav--mobile" ).toggleClass('app-mobile-nav--active');
-  });
-
-  //show subnav links when clicking top level
-  $('.learning-section-mobile-nav > a').click(function() {
-    $(this).parent().children('ul.app-mobile-subnav-section').toggle();
-  });
-
-  //disable top level section click on mobile nav
-  $('.learning-section-mobile-nav .top-level-link').click(function(e) {
-    e.preventDefault();
-  });
-
   //clipboard
   $('#clipboard_copier').click(function() {
     copyToClipboard();
@@ -57,3 +34,59 @@ $(document).ready(function() {
   });
 
 });
+
+const menuButton = document.querySelector('.js-app-mobile-nav-toggler');
+const mobileSubNav = document.querySelector('.app-subnav--mobile');
+
+//Set aria attributes when JS is available
+menuButton.setAttribute('aria-expanded', 'false');
+mobileSubNav.setAttribute('aria-hidden', 'true');
+
+menuButton.addEventListener('click', function() {
+  //Menu open
+  if (menuButton.classList.contains('is-active')) {
+    menuButton.classList.add('is-active');
+    mobileSubNav.classList.add('app-mobile-nav--active');
+    menuButton.setAttribute('aria-expanded', 'false')
+    mobileSubNav.setAttribute('aria-hidden', 'true')
+  } else { //menu closed//
+    menuButton.classList.remove('is-active');
+    mobileSubNav.classList.remove('app-mobile-nav--active');
+    menuButton.setAttribute('aria-expanded', 'true')
+    mobileSubNav.setAttribute('aria-hidden', 'false')
+  }
+});
+
+// // Sub navigation
+
+// // Loop through and find all the sub headings
+const subLinks = document.querySelectorAll('.app-mobile-nav-subnav-toggler');
+const subNavActive = ('app-mobile-nav__subnav--active');
+
+// build an array of the subLinks
+Array.from(subLinks).forEach(link => {
+
+  // listen for a click on subLinks
+  link.addEventListener('click', function(e) {
+    //rules for aria attributes when submenu is closed
+    e.preventDefault();
+    if (this.nextElementSibling.classList.contains(subNavActive)) {
+      this.nextElementSibling.classList.remove(subNavActive)
+      this.firstElementChild.setAttribute('aria-expanded', 'false')
+      this.nextElementSibling.setAttribute('aria-hidden', 'true')
+    //rules for aria attributes when submenu is open
+    } else {
+      this.nextElementSibling.classList.add(subNavActive)
+      this.firstElementChild.setAttribute('aria-expanded', 'true')
+      this.nextElementSibling.setAttribute('aria-hidden', 'false')
+    }
+  });
+});
+
+const stickyMenu = document.querySelector('.js-app-mobile-nav-toggler');
+const mobileStickySubNav = document.querySelector('.app-subnav--mobile');
+
+stickyMenu.onclick = () => {
+  stickyMenu.classList.toggle('is-active');
+  mobileStickySubNav.classList.toggle('app-mobile-nav--active');
+}


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/HFEYP-355

### Changes proposed in this pull request

Allows the screenreader to know when a grouping is collapsed or expanded.

### Guidance to review

Needed to remove some of the existing javascript which conflicted with the way rinto had done things in the prototype, so need to check that no existing functionality was lost with regards to:

* toggle menu button arrow
* 2nd level nav stays visible
* show mobile nav when clicking hamburger (do we have a hamburger?)
* show subnav links when clicking top level
* disable top level section click on mobile nav

The above taken from the comments in the deleted javascript.  Checked locally and it appears the functions still exist, but need to confirm.  If we did lose anything, then I suggest we go back to the prototype and use the code there
