### PR TITLE
removal of tab and tidy-up menu-button

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -46,8 +46,8 @@
           </span>
         </span>
       </a>
-      <div role="tablist" class="app-header-mobile-nav-toggler-wrapper">
-        <button role="tab" aria-controls="mobile-menu-nav" id="app-mobile-nav-toggler" type="button" class="govuk-js-header-toggle govuk-button eyfs-menu-button--border app-header-mobile-nav-toggler js-app-mobile-nav-toggler" aria-label="Show or hide Top Level Navigation" aria-expanded="false">Menu</button>
+      <div class="app-header-mobile-nav-toggler-wrapper">
+        <button aria-controls="mobile-menu-nav" id="app-mobile-nav-toggler" class="govuk-js-header-toggle govuk-button eyfs-menu-button--border app-header-mobile-nav-toggler js-app-mobile-nav-toggler" aria-expanded="false">Menu</button>
       </div>
     </div>
     <div class="govuk-header__content">
@@ -58,7 +58,7 @@
     </div>
   </div>
   </header>
-  
+
   <div class="govuk-width-container" role="navigation" id="mobile-menu-nav" aria-label="Mobile menu navigation">
     <%= render 'layouts/mobile_menu' %>
   </div>


### PR DESCRIPTION
### Screen reader JAWS plays 'tab 1 of 1' and 'top level navigation', and not playing content as Dev prototype.

### role tablist removed, btn role tab removed, type btn removed, aria-label removed.

### Screen reader should state 'menu button', 'press enter to activate', as prototype.  'Expand' and 'collapse' should still be heard.

