### PR TITLE
Distinct page titles in content pages

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -1,9 +1,8 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
 <head>
-  <meta name="robots" content="noindex, nofollow">
   <meta name="Cache-Control" content="max-age=3500, public">
-  <title>Help for early years providers</title>
+  <title>Early Years - <%= @page.title %></title>
   <%= render 'layouts/google_analytics_header' if cookies[:track_google_analytics] == 'Yes' %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>

--- a/app/views/layouts/landing_page_layout.html.erb
+++ b/app/views/layouts/landing_page_layout.html.erb
@@ -10,7 +10,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="robots" content="noindex, nofollow" />
 
   <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
   <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>

--- a/app/views/layouts/settings.html.erb
+++ b/app/views/layouts/settings.html.erb
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
 <head>
-  <meta name="robots" content="noindex, nofollow">
   <title>Help for early years providers</title>
   <%= render 'layouts/google_analytics_header' if cookies[:track_google_analytics] == 'Yes' %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
### Context
The page titles were all the same

They need to say what the page is about

### Changes proposed in this pull request

Distinct page titles for every page

Also, the nofollow meta tag was still in here, so it is removed. 

### Guidance to review
Check that all pages, apart from the landing page, have distinct titles
