### PR TITLE
Unique page title

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
 <head>
   <meta name="Cache-Control" content="max-age=3500, public">
-  <title>Help for early years providers</title>
+  <title>Early Years - <%= @page.title %></title>
   <%= render 'layouts/google_analytics_header' if cookies[:track_google_analytics] == 'Yes' %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>


### PR DESCRIPTION
### Context
In the http header, pages should have unique titles

### Changes proposed in this pull request


### Guidance to review
Check that a page, say Exploring language, has the http header 'Early Years - Exploring language'

You can view the source of the page to check this
