### PR TITLE
Unique page titles

### DIFF
--- a/app/views/layouts/cms.html.erb
+++ b/app/views/layouts/cms.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <title>Help for early years providers (editing content)</title>
+    <title>Editing content - Help for early years providers</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
 <head>
   <meta name="Cache-Control" content="max-age=3500, public">
-  <title>Early Years - <%= @page.title %></title>
+  <title><%= @page.title %> | Help for early years providers</title>
   <%= render 'layouts/google_analytics_header' if cookies[:track_google_analytics] == 'Yes' %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
 <head>
   <meta name="Cache-Control" content="max-age=3500, public">
-  <title>Help for early years providers</title>
+  <title>Early Years - <%= @page.title %></title>
   <%= render 'layouts/google_analytics_header' if cookies[:track_google_analytics] == 'Yes' %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>

--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -7,9 +7,7 @@ CanonicalRails.setup do |config|
 
   # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
 
-  # TODO: update when we have domain
-  config.host = "www.education.gov.uk"
-  config.port # = '3000'
+  config.host = "help-for-early-years-providers.education.gov.uk"
 
   # http://en.wikipedia.org/wiki/URL_normalization
   # Trailing slash represents semantics of a directory, ie a collection view - implying an :index get route;


### PR DESCRIPTION
### Context
A one line hotfix for the production branch

All content pages should have unique page titles

At the moment they all say "Early Years Reform", and this might be messing up Google Analytics

### Changes proposed in this pull request

### Guidance to review
Open a page, say Literacy, and check that the page title is 'Early Years - Literacy'

