### PR TITLE
Unique page titles and correct cannonical meta tags into main

### DIFF
--- a/app/views/layouts/cms.html.erb
+++ b/app/views/layouts/cms.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <title>Editing content - Help for early years providers</title>
+    <title>Editing content - Help for early years providers | GOV.UK</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>

--- a/app/views/layouts/cms.html.erb
+++ b/app/views/layouts/cms.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <title>Help for early years providers (editing content)</title>
+    <title>Editing content - Help for early years providers</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>
@@ -63,11 +63,11 @@
       </div>
     </header>
 
-    <div class="govuk-width-container">
-      <main class="govuk-main-wrapper" role="main" id="main-content" >
+    <main role="main" id="main-content" class="govuk-width-container">
+      <div class="govuk-main-wrapper" >
         <%= yield %>
-      </main>
-    </div>
+      </div>
+    </main>
 
     <footer class="govuk-footer " role="contentinfo">
       <%= render 'layouts/footer_content' %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
 <head>
   <meta name="Cache-Control" content="max-age=3500, public">
-  <title><%= @page.title %> | Help for early years providers</title>
+  <title><%= @page.title %> | Help for early years providers | GOV.UK</title>
   <%= render 'layouts/google_analytics_header' if cookies[:track_google_analytics] == 'Yes' %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>

--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
 <head>
   <meta name="Cache-Control" content="max-age=3500, public">
-  <title>Help for early years providers</title>
+  <title><%= @page.title %> | Help for early years providers</title>
   <%= render 'layouts/google_analytics_header' if cookies[:track_google_analytics] == 'Yes' %>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
@@ -45,34 +45,30 @@
           </span>
         </span>
       </a>
-      <div class="app-header-mobile-nav-toggler-wrapper">
-        <button aria-controls="mobile-menu-nav" id="app-mobile-nav-toggler" class="govuk-js-header-toggle govuk-button eyfs-menu-button--border app-header-mobile-nav-toggler js-app-mobile-nav-toggler" aria-expanded="false">Menu</button>
-      </div>
     </div>
     <div class="govuk-header__content">
       <a href="/" class="govuk-header__link govuk-header__link--service-name">
         Help for early years providers
       </a>
-    </div>
+      <button type="button" role="button" class=" govuk-header__menu-button govuk-js-header-toggle" aria-controls="mobile-menu-nav" aria-label="Show or hide Top Level Navigation">Menu</button>
     </div>
   </div>
   </header>
-
-  <div class="govuk-width-container" role="navigation" id="mobile-menu-nav" aria-label="Mobile menu navigation">
-    <%= render 'layouts/mobile_menu' %>
-  </div>
 
   <aside class="govuk-width-container" role="complementary">
     <%= render 'layouts/phase_banner' %>
   </aside>
 
+  <nav class="govuk-width-container" role="navigation" id="mobile-menu-nav" aria-label="Mobile menu navigation">
+    <%= render 'layouts/mobile_menu' %>
+  </nav>
 
   <nav class="govuk-width-container" role="navigation" aria-label="Breadcrumbs">
     <%= render 'layouts/breadcrumbs' %>
   </nav>
 
-  <div class="govuk-width-container">
-    <main class="govuk-main-wrapper" role="main">
+  <main class="govuk-width-container" role="main">
+    <div class="govuk-main-wrapper">
       <div class="govuk-grid-row">
         <nav role="navigation" class="govuk-grid-column-one-third desktop-menu" aria-label="Desktop menu navigation">
           <%= render 'layouts/desktop_menu' %>
@@ -129,8 +125,8 @@
           </div>
         </div>
       </div>
-    </main>
-  </div>
+    </div>
+  </main>
 
   <footer class="govuk-footer " role="contentinfo">
     <%= render 'layouts/footer_content' %>

--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -7,9 +7,7 @@ CanonicalRails.setup do |config|
 
   # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
 
-  # TODO: update when we have domain
-  config.host = "www.education.gov.uk"
-  config.port # = '3000'
+  config.host = "help-for-early-years-providers.education.gov.uk"
 
   # http://en.wikipedia.org/wiki/URL_normalization
   # Trailing slash represents semantics of a directory, ie a collection view - implying an :index get route;


### PR DESCRIPTION
### Context
Repeating the hotfilx changes that went into the production branch this morning

### Changes proposed in this pull request
The meta tag for canonical URLs is now set to the correct URL
Content pages now all have different titles

### Guidance to review
Check that the meta tag for canonical has this URL in it;
https://help-for-early-years-providers.education.gov.uk/

Also check the the Literacy page has a HTML <title> tag containing the work 'Litercy'
