### PR TITLE
Styling the mobile menu

### DIFF
--- a/app/views/layouts/content.html.erb
+++ b/app/views/layouts/content.html.erb
@@ -58,9 +58,7 @@
   </div>
   </header>
 
-  <div class="govuk-width-container" role="navigation" id="mobile-menu-nav" aria-label="Mobile menu navigation">
-    <%= render 'layouts/mobile_menu' %>
-  </div>
+  <%= render 'layouts/mobile_menu' %>
 
   <aside class="govuk-width-container" role="complementary">
     <%= render 'layouts/phase_banner' %>

--- a/app/webpacker/styles/_eyfs-mobile-navigation.scss
+++ b/app/webpacker/styles/_eyfs-mobile-navigation.scss
@@ -13,7 +13,6 @@
     border-bottom: 1px solid #b1b4b6;
     color: #fff;
   }
-  
   .app-mobile-nav--active {
     display:block;
    }
@@ -46,15 +45,13 @@
 
       }
     }
-    
    .app-mobile-nav-subnav-toggler {
     position:relative;
-  
    }
 
    .learning-section-mobile-nav {
     position: relative;
-    padding: 16px 0px 16px 0px;
+    padding: 16px 0px 16px 15px;
     background-color: #f8f8f8;
   }
 
@@ -95,7 +92,8 @@
    }
    .app-mobile-nav__subnav-item--current {
     padding-left:16px;
-    border-left:4px solid #1d70b8
+    border-left:4px solid #1d70b8;
+    margin-left: 2px;
    }
    .app-mobile-nav__theme {
     font-family:"GDS Transport",arial,sans-serif;
@@ -344,4 +342,3 @@
     overflow-x:hidden;
     border-right:0
    }
-  


### PR DESCRIPTION
### Context
[  I also messed up the previous PR for this, so am starting again ]

360 - Mobile menu - make the grey areas around top level menus go to the left margin

### Changes proposed in this pull request
While testing this, it uncovered issue #384, that the sub menus are not displayed for the selected top level menu

### Guidance to review
