### PR TITLE
docker related seed

### DIFF
--- a/entrypoints/docker-entrypoint.sh
+++ b/entrypoints/docker-entrypoint.sh
@@ -7,7 +7,5 @@ if [ -f tmp/pids/server.pid ]; then
   rm tmp/pids/server.pid
 fi
 
-bundle exec rake db:prepare db:seed
-
 # Start the application
 bundle exec rails s -b 0.0.0.0

--- a/entrypoints/docker-entrypoint.sh
+++ b/entrypoints/docker-entrypoint.sh
@@ -7,5 +7,7 @@ if [ -f tmp/pids/server.pid ]; then
   rm tmp/pids/server.pid
 fi
 
+bundle exec rake db:prepare
+
 # Start the application
 bundle exec rails s -b 0.0.0.0


### PR DESCRIPTION
### Do not want db seed to populate environments

### Removed db:seed from docker_entrypoint.sh (which is run by docker, which in turn is run from deploy)

### There are several places where seed is run and other areas may require seed command to be removed.  This is first change and potentially only change required.

