### PR TITLE
Mobile menu now shows sub menus as open

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -9,6 +9,14 @@ module ContentHelper
   end
 
   def is_current?(page)
-    page.slug == params[:slug]
+    params[:slug] == page.slug
+  end
+
+  # This is not nice, but necessary. It is here because of the
+  # 'Overview' menu items inserted into the mobile menu.  Without
+  # this extra check, the Overview menus appear as current when
+  # they are now. Sorry
+  def is_mobile_menu_section_current?(page)
+    params[:slug] == page.slug || params[:section] == page.slug
   end
 end

--- a/app/views/layouts/_mobile_menu.html.erb
+++ b/app/views/layouts/_mobile_menu.html.erb
@@ -5,7 +5,7 @@
         <div class="learning-section-mobile-nav app-mobile-nav-subnav-toggler">
           <%= link_to(raw('<h4 class="app-subnav__theme ">' + top_level_page.title + '</h4>'), path_for_this_page(top_level_page), class: "govuk-link app-subnav__link govuk-link--no-visited-state top-level-link") %>
         </div>
-        <ul class="app-mobile-nav__list app-mobile-subnav-section app-mobile-nav__subnav <%= is_current?(top_level_page) ? 'app-mobile-nav__subnav--active' : '' %>">
+        <ul class="app-mobile-nav__list app-mobile-subnav-section app-mobile-nav__subnav <%= is_mobile_menu_section_current?(top_level_page) ? 'app-mobile-nav__subnav--active' : '' %>">
           <li class="app-mobile-nav__subnav-item <%= is_current?(top_level_page) ? 'app-mobile-nav__subnav-item--current' : '' %>">
             <%= link_to('Overview', path_for_this_page(top_level_page), aria: {label: "#{top_level_page.title} Overview"}, class: "govuk-link app-subnav__link govuk-link--no-visited-state") %>
           </li>


### PR DESCRIPTION
### Context
Fix for the regression described in 

https://dfedigital.atlassian.net/jira/software/projects/HFEYP/boards/83?selectedIssue=HFEYP-384

### Changes proposed in this pull request
On the mobile menu, the correct sub pages will now be visible when a top level page is selected

### Guidance to review
Go to /communication-and-language
Make the window as narrow as it will go (or use ngrok to look at it on a mobile)
Click on Exploring Language
Click on the Menu button
Verify that the Comunication and Language sub pages are shown in the mobile menu
