### PR TITLE
I should have removed this ul before now

### DIFF
--- a/app/views/layouts/_mobile_menu.html.erb
+++ b/app/views/layouts/_mobile_menu.html.erb
@@ -1,4 +1,4 @@
-<nav class="app-subnav--mobile app-mobile-nav js-app-mobile-nav">
+<nav class="app-subnav--mobile app-mobile-nav js-app-mobile-nav" id="mobile-menu-nav">
   <ul class="app-mobile-nav__list" aria-label="Navigation menu">
     <% ContentPage.top_level.order_by_position.each do |top_level_page| %>
       <li>

--- a/app/views/layouts/_mobile_menu.html.erb
+++ b/app/views/layouts/_mobile_menu.html.erb
@@ -10,11 +10,9 @@
             <%= link_to('Overview', path_for_this_page(top_level_page), aria: {label: "#{top_level_page.title} Overview"}, class: "govuk-link app-subnav__link govuk-link--no-visited-state") %>
           </li>
           <% top_level_page.children.order_by_position.each do |child| %>
-            <ul class="app-mobile-nav__list">
-              <li class="app-mobile-nav__subnav-item <%= is_current?(child) ? 'app-mobile-nav__subnav-item--current' : '' %>">
-                <%= link_to(child.title, path_for_this_page(child), class: "govuk-link app-subnav__link govuk-link--no-visited-state") %>
-              </li>
-            </ul>
+            <li class="app-mobile-nav__subnav-item <%= is_current?(child) ? 'app-mobile-nav__subnav-item--current' : '' %>">
+              <%= link_to(child.title, path_for_this_page(child), class: "govuk-link app-subnav__link govuk-link--no-visited-state") %>
+            </li>
           <% end %>
         </ul>
       </li>


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/HFEYP-400

Also https://dfedigital.atlassian.net/browse/HFEYP-399
 
### Changes proposed in this pull request
Tpo fix 400, I removed a ul tag that should have been removed in an earlier PR

The cause of 399 is probably the the aria tag mentioned, mobile-menu-nav, should be the id of the mobile menu. 

### Guidance to review
Check that the mobile menu passes the Axe test in that Jira issue, 400

Same for 399.  
