### PR TITLE
Add missing meta tags to the landing page

### DIFF
--- a/app/views/layouts/landing_page_layout.html.erb
+++ b/app/views/layouts/landing_page_layout.html.erb
@@ -5,6 +5,9 @@
   <title>
     Help for early years providers - GOV.UK
   </title>
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+  <%= canonical_tag %>
   <%= render 'layouts/google_analytics_header' if cookies[:track_google_analytics] == 'Yes' %>
   <meta Cache-Control="max-age=3500, public">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/HFEYP-398

### Changes proposed in this pull request
These meta tags are in the content pages, but not in the landing page

### Guidance to review
View the source for the landing page and check that this is included


&lt;meta property="og:url" content="https://help-for-early-years-providers.education.gov.uk:3000/" /&gt;&lt;link href="https://help-for-early-years-providers.education.gov.uk:3000/" rel="canonical" /&gt;



