### PR TITLE
Explain the clamav-rest server set up in CLAMAV.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ we do not currently follow Semantic Versioning or track version numbers.
 
 ### Added
 ### Changed
+  [PR-262]( https://github.com/DFE-Digital/early-years-foundation-reform/pull/262 )
+
+  [HFEYP-405]( https://dfedigital.atlassian.net/browse/HFEYP-405 )
+
+  Explain the clamav-rest server set up in CLAMAV.md
+    * manifest.yml file used to create private servers in eyfs-prod
+    * default clamav service url points to new server in eyfs-prod
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CLAMAV.md
+++ b/CLAMAV.md
@@ -1,0 +1,42 @@
+Instructions for setting up clamav-rest server:
+
+1) Log into cloud front from the command line:
+
+`cf login -u EMAIL`
+
+2) Select space to add server
+```
+Select a space:
+1. eyfs-dev
+2. eyfs-pre-prod
+3. eyfs-prod
+4. eyfs-test
+```
+3) Create the `clamav-rest` server with the following command:
+
+`cf push`
+
+The docker image, app name and route are in the `manifest.yml` file.
+
+4) Create the network policy for each cms application (dev, test, preprod and prod).  
+
+```
+cf add-network-policy PUBLIC_APPNAME PRIVATE_APPNAME -s eyfs-prod --protocol tcp --port 9000
+```
+
+i.e. for eyfs-cms-dev app in eyfs-dev space
+```
+cf add-network-policy eyfs-cms-dev eyfs-clamav-rest-private -s eyfs-prod --protocol tcp --port 9000
+```
+
+5) The default for all applications is set to: 
+
+```
+http://eyfs-clamav-rest-private.apps.internal:9000/scan
+```
+
+So currently no need to set the url for the application.  If this is needed (i.e. you want to test a different clamav-rest server) then you can set the RESTY_SERVICE_URL env var. So, for example, if a new private appname is created called `new-eyfs-clamav-rest-private` then the CMS app would need the following set:
+
+```
+cf set-env eyfs-cms-dev RESTY_SERVICE_URL http://new-eyfs-clamav-rest-private.apps.internal:9000/scan
+```

--- a/config/initializers/ratonvirus_resty.rb
+++ b/config/initializers/ratonvirus_resty.rb
@@ -1,6 +1,6 @@
 Ratonvirus::Resty.configure do |config|
   # Sets the base url for api requests
-  config.service_url = ENV.fetch("RESTY_SERVICE_URL", "https://eyfs-clamav-rest.london.cloudapps.digital/scan")
+  config.service_url = ENV.fetch("RESTY_SERVICE_URL", "http://eyfs-clamav-rest-private.apps.internal:9000/scan")
   # Optional sets the username for api requests
   config.username = ENV.fetch("RESTY_USERNAME", nil)
   # Optional sets the password for api requests

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,8 @@
 ---
 applications:
-- name: govuk-rails-boilerplate
-  buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack.git
-    - https://github.com/cloudfoundry/nodejs-buildpack
+  - name: eyfs-clamav-rest-private
+    instances: 3
+    docker:
+      image: niilo/clamav-rest
+    routes:
+      - route: eyfs-clamav-rest-private.apps.internal


### PR DESCRIPTION
### Context

Explain the `clamav-rest` server set up in CLAMAV.md

* manifest.yml file used to create private servers in eyfs-prod
* default clamav service url points to new server in eyfs-prod

### Changes proposed in this pull request

### Guidance to review

