### PR TITLE
Only use top level headings in Faker markdown - to avoid triggering Axe

### DIFF
--- a/spec/factories/content_pages.rb
+++ b/spec/factories/content_pages.rb
@@ -9,7 +9,7 @@ end
 FactoryBot.define do
   factory :content_page do
     title { sentence_without_puncutation }
-    markdown { Faker::Markdown.headers }
+    markdown { "# Fake title - #{Faker::Lorem.word}" }
     parent_id { nil }
     position { ContentPage.maximum("position").nil? ? 1 : ContentPage.maximum("position") + 1 }
   end


### PR DESCRIPTION
### Context
The ContentPage Factory was producing pages with <h4> titles in the markdown, and these made Axe Accessibility test fails

### Changes proposed in this pull request
Just use # 1, h1 headings in Faker Markdown

### Guidance to review

