### PR TITLE
Remove 2px padding from mobile menu

### DIFF
--- a/app/webpacker/styles/_eyfs-mobile-navigation.scss
+++ b/app/webpacker/styles/_eyfs-mobile-navigation.scss
@@ -93,7 +93,6 @@
    .app-mobile-nav__subnav-item--current {
     padding-left:16px;
     border-left:4px solid #1d70b8;
-    margin-left: 2px;
    }
    .app-mobile-nav__theme {
     font-family:"GDS Transport",arial,sans-serif;


### PR DESCRIPTION
### Context
Remove the 2px padding from the left of the mobile menu

### Changes proposed in this pull request

### Guidance to review
The lefthand blue border of the selected menu item should now be flush on the left