### PR TITLE
Use errors instead of notices to let the user know that they don't have permission

### DIFF
--- a/app/controllers/content_pages_controller.rb
+++ b/app/controllers/content_pages_controller.rb
@@ -22,13 +22,9 @@ class ContentPagesController < ApplicationController
 
   # GET /content_pages/1/edit
   def edit
-    authorize @content_page, :edit?
     @md = GovspeakToHTML.new.translate_markdown(@content_page.markdown)
 
     @content_page
-  rescue Pundit::NotAuthorizedError
-    flash[:notice] = "You don't have permission to edit pages"
-    redirect_to action: "index"
   end
 
   # POST /content_pages
@@ -43,8 +39,8 @@ class ContentPagesController < ApplicationController
         render :new
       end
     rescue Pundit::NotAuthorizedError
-      flash[:notice] = "You don't have permission to create pages"
-      redirect_to action: "index"
+      @content_page.errors.add(:base, "You don't have permission to create pages")
+      render :new
     end
   end
 
@@ -57,7 +53,12 @@ class ContentPagesController < ApplicationController
     else
       render :edit
     end
+
+  rescue Pundit::NotAuthorizedError
+    @content_page.errors.add(:base, "You don't have permission to change pages")
+    render :edit
   end
+
 
   # DELETE /content_pages/1
   def destroy

--- a/app/controllers/content_pages_controller.rb
+++ b/app/controllers/content_pages_controller.rb
@@ -30,7 +30,6 @@ class ContentPagesController < ApplicationController
   # POST /content_pages
   def create
     @content_page = ContentPage.new(content_page_params)
-
     begin
       authorize @content_page, :create?
       if @content_page.save
@@ -47,23 +46,19 @@ class ContentPagesController < ApplicationController
   # PATCH/PUT /content_pages/1
   def update
     authorize @content_page, :update?
-
     if @content_page.update(content_page_params)
       redirect_to content_pages_path(@content_page), notice: "Content page was successfully updated."
     else
       render :edit
     end
-
   rescue Pundit::NotAuthorizedError
     @content_page.errors.add(:base, "You don't have permission to change pages")
     render :edit
   end
 
-
   # DELETE /content_pages/1
   def destroy
     authorize @content_page, :destroy?
-
     @content_page.destroy!
     redirect_to content_pages_url, notice: "Content page was successfully destroyed."
   end

--- a/app/views/content_pages/index.html.erb
+++ b/app/views/content_pages/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice" class="govuk-error-message"><%= notice %></p>
-
 <h1 class="govuk-heading-l">Edit pages</h1>
 
 <br/>

--- a/app/views/content_pages/show.html.erb
+++ b/app/views/content_pages/show.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <p>
   <strong>Title:</strong>
   <%= @content_page.title %>

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -55,9 +55,17 @@ RSpec.feature "View pages", type: :feature do
 
   scenario "A user with the role of reader should be not be able to edit pages in the CMS" do
     sign_in FactoryBot.create(:user, :reader)
+    attributes = FactoryBot.attributes_for :content_page
+
     visit "/cms/pages/#{child_page.id}/edit"
 
-    expect(page.body).to include("You don't have permission to edit pages")
+    page.find_field("content_page[title]").set(attributes[:title])
+    page.find_field("content_page[markdown]").set(attributes[:markdown])
+    page.find_field("content_page[position]").set(rand(10_000))
+
+    page.click_button("Update Content page")
+
+    expect(page.body).to include("You don't have permission to change pages")
   end
 
   scenario "A user with the role of editor should be able to create pages in the CMS" do


### PR DESCRIPTION
### Context
A fix for the intermittent test fails

### Changes proposed in this pull request
Use errors instead of flash notices to tell the user that they don't have sufficient permission

### Guidance to review
The specs should all pass, repeatedly !
