### PR TITLE
Use RACK to block http trace

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ require "action_view/railtie"
 # require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
+require_relative "../lib/rack/reject_trace"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -37,6 +39,7 @@ module GovukRailsBoilerplate
     # (see https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#x-xss-protection-header)
     config.action_dispatch.default_headers['X-XSS-Protection'] = "0"
 
+    config.middleware.use Rack::RejectTrace
     config.middleware.use Rack::Deflater
   end
 end

--- a/lib/rack/reject_trace.rb
+++ b/lib/rack/reject_trace.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Rack
+  class RejectTrace
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      return @app.call(env) unless env["REQUEST_METHOD"] == "TRACE"
+
+      [405, {}, []]
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://dfedigital.atlassian.net/browse/HFEYP-241

### Changes proposed in this pull request

My attempt at blocking HTTP TRACE.  I found this by googling and finding the implementation here: https://github.com/lockstep/rails_new

It made sense, however unclear how to test it.

### Guidance to review

Still looking for a CURL command to test....