### PR TITLE
425 - allow JS to reach hotjar.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ we do not currently follow Semantic Versioning or track version numbers.
 
   Update page titles (394) and add contact page (410), cookie-policy page now uses standard layout
 
+  [HYEYP-425](https://dfedigital.atlassian.net/browse/HFEYP-425) - allow JS to reach hotjar.com
 ### Changed
   [PR-262]( https://github.com/DFE-Digital/early-years-foundation-reform/pull/262 )
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -23,7 +23,8 @@ S3_DOMAINS = [
 GOOGLE_ANALYTICS_DOMAINS = %w[www.google-analytics.com
                               ssl.google-analytics.com
                               stats.g.doubleclick.net
-                              www.googletagmanager.com].freeze
+                              www.googletagmanager.com
+                              static.hotjar.com].freeze
 
 GOOGLE_STATIC_DOMAINS = %w[www.gstatic.com].freeze
 


### PR DESCRIPTION
### Context
When the hotjar tracking feature is enabled again, this change should stop the CORs error

### Changes proposed in this pull request
Add hotjar.com to the list of sites that the browser can load JS from

### Guidance to review
Check in the console that the pages do not cause any JS errors
