### PR TITLE
435 - fix contrast on cookie link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ we do not currently follow Semantic Versioning or track version numbers.
   [HFEYP-410]( https://dfedigital.atlassian.net/browse/HFEYP-410 )
 
   Update page titles (394) and add contact page (410), cookie-policy page now uses standard layout
+ 
+  [HFEYP-435]( https://dfedigital.atlassian.net/browse/HFEYP-435) Updates style of cookie-banner to keep the default black on yellow colour of selected links
 
 ### Changed
   [PR-262]( https://github.com/DFE-Digital/early-years-foundation-reform/pull/262 )

--- a/app/webpacker/styles/_cookie-banner.scss
+++ b/app/webpacker/styles/_cookie-banner.scss
@@ -42,7 +42,6 @@
   a.govuk-link {
     @include govuk-font(19);
     line-height: 2em !important;
-    color: $govuk-brand-colour;
   }
 
   .govuk-button-group .govuk-button {


### PR DESCRIPTION
### Context
When accepting cookies, the link "View Cookies" was showing as blue on yellow

https://dfedigital.atlassian.net/browse/HFEYP-435

### Changes proposed in this pull request
It should be black on yellow

### Guidance to review
Clear the cookies and go to the site
Check that the link to View Cookies is black on yellow when clicked on (hold the mouse down and keep it)

![Screenshot 2021-06-07 at 13 04 46](https://user-images.githubusercontent.com/3352035/121013769-2a5f3500-c791-11eb-887f-36cb2c39c0ab.png)

