### PR TITLE
First attempt to create network policy via terraform

### DIFF
--- a/terraform/app/modules/paas/data.tf
+++ b/terraform/app/modules/paas/data.tf
@@ -7,10 +7,14 @@ data cloudfoundry_space space {
   org  = data.cloudfoundry_org.org.id
 }
 
+data cloudfoundry_space prod_space {
+  name = "eyfs_prod"
+  org = data.cloudfoundry_org.org.id
+}
+
 data cloudfoundry_domain cloudapps_digital {
   name = "london.cloudapps.digital"
 }
-
 
 data cloudfoundry_service postgres {
   name = "postgres"

--- a/terraform/app/modules/paas/main.tf
+++ b/terraform/app/modules/paas/main.tf
@@ -61,6 +61,14 @@ resource cloudfoundry_app cms_app {
   environment = local.app_environment
 }
 
+resource "cf_network_policy" "clamav-rest-private" {
+  source_app = local.cms_app_name
+  destination_app = "eyfs-clamav-rest-private"
+  space = data.prod_space
+  protocol = "tcp"
+  port = "9000"
+}
+
 resource cloudfoundry_route web_app_route {
   domain   = data.cloudfoundry_domain.cloudapps_digital.id
   space    = data.cloudfoundry_space.space.id


### PR DESCRIPTION
### Context

Need to create cloud front network policy via terraform for it to be around after deployment

### Changes proposed in this pull request

Adds network policy resource

### Guidance to review

You can check network policies in each space:

`cf network-policies`

```
❯ cf network-policies
Listing network policies in org dfe / space eyfs-dev as brett.mchargue@digital.education.gov.uk...

source         destination                protocol   ports   destination space   destination org
eyfs-cms-dev   eyfs-clamav-rest-private   tcp        9000    eyfs-prod           dfe
```