### PR TITLE
418 Add message for large files

### DIFF
--- a/app/views/content_assets/_form.html.erb
+++ b/app/views/content_assets/_form.html.erb
@@ -17,11 +17,12 @@
     <%= form.label :alt_text, :class => 'govuk-label' %>
     <%= form.text_field :alt_text, :class => 'govuk-input govuk-!-width-three-quarters' %>
     <%= form.file_field :asset_file %>
+    <p class="govuk-body" id="content_asset_file_size"></p>
   </div>
 
 <div class="govuk-grid-row">
 <div class="govuk-grid-column-one-half">
-  <%= form.submit('Submit', :class => "govuk-button") %>
+  <%= form.submit('Submit', :class => "govuk-button", disabled: true) %>
 </div>
 </div>
 

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -99,3 +99,15 @@ if (stickyMenu) {
     mobileStickySubNav.classList.toggle('app-mobile-nav--active');
   }
 }
+
+$('#content_asset_asset_file').on('change', function() {
+  const size = (this.files[0].size / 1024 /1024).toFixed(2);
+  var $submit = $('input[type="submit"]');
+  $submit.prop('disabled', true);
+  if (size > 2) {
+    $("#content_asset_file_size").html('<b>' + 'This file size is too large: ' + size + " MB" + '</b>');
+  } else {
+    $submit.prop('disabled', false);
+    $("#content_asset_file_size").html('<b>' + 'This file size is: ' + size + " MB" + '</b>');
+  } 
+});

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,8 +71,8 @@ en:
               password_complexity:
                 digit: Password must contain at least 2 digits
                 lower: Password must contain at least 2 lowercase characters
-                upper: Password much contain at least 2 uppercase characters
-                symbol: Password much contain at least 2 special characters or non-alphanumeric characters
+                upper: Password must contain at least 2 uppercase characters
+                symbol: Password must contain at least 2 special characters or non-alphanumeric characters
             role:
               blank: Select an editor or administrator role type
             password_confirmation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
             password:
               too_short: Password must be a minimum of 8 characters long
               blank: Password must not be blank
+              equal_to_current_password: 'Password must be different than the current password'
               password_complexity:
                 digit: Password must contain at least 2 digits
                 lower: Password must contain at least 2 lowercase characters


### PR DESCRIPTION
### Context
[HFEYP-418](https://dfedigital.atlassian.net/browse/HFEYP-418)
[HFEYP-490](https://dfedigital.atlassian.net/browse/HFEYP-490)
[HFEYP-491](https://dfedigital.atlassian.net/browse/HFEYP-491)

### Changes proposed in this pull request

Add a check on the client side for file size before uploading content asset.  Check is done on the client side (browser) and the submit button is only enabled if the file size is less than 2MB

Small fix for missed password error message

### Guidance to review

