### PR TITLE
Make mechanize available outside test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,6 @@ group :test do
 
   gem "capybara", "~> 3.34"
   gem "launchy"
-  gem "mechanize"
   gem "rspec-rails", "~> 5.0"
   gem "selenium-webdriver"
   gem "simplecov",  "~> 0.21", require: false
@@ -101,3 +100,5 @@ gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 gem "devise-security", "~> 0.16.0"
 
 gem "govuk_design_system_formbuilder", "~> 2.7"
+
+gem "mechanize"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,8 @@ GEM
     nio4r (2.5.7)
     nokogiri (1.11.7-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.11.7-x86_64-darwin)
+      racc (~> 1.4)
     nokogumbo (2.0.5)
       nokogiri (~> 1.8, >= 1.8.4)
     orm_adapter (0.5.0)
@@ -501,6 +503,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-20
+  x86_64-darwin-20
 
 DEPENDENCIES
   active_storage_validations (~> 0.9)


### PR DESCRIPTION
### Context

I think `mechanise` needs to be available outside of just test, as it is used in /app

### Changes proposed in this pull request

### Guidance to review

