### PR TITLE
497 and 501 Improve assets page accessibility, google site verification

### DIFF
--- a/app/views/content_assets/_form.html.erb
+++ b/app/views/content_assets/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: content_asset, local: true) do |form| %>
+<%= form_with(model: content_asset, local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
   <% if content_asset.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(content_asset.errors.count, "error") %> prohibited this asset from being saved:</h2>
@@ -12,17 +12,14 @@
   <% end %>
 
   <div class="govuk-form-group">
-    <%= form.label :title, :class => 'govuk-label' %>
-    <%= form.text_field :title, :class => 'govuk-input govuk-!-width-three-quarters' %>
-    <%= form.label :alt_text, :class => 'govuk-label' %>
-    <%= form.text_field :alt_text, :class => 'govuk-input govuk-!-width-three-quarters' %>
-    <%= form.file_field :asset_file %>
+    <%= form.govuk_text_field :title, width: 'three-quarters' %>
+    <%= form.govuk_text_field :alt_text, label: { text: "Alternate text" }, width: 'three-quarters' %>
+    <%= form.govuk_file_field :asset_file, label: { text: "Asset file" }, width: 'one-half', hint: { text: "Upload an asset file less than 2MB.</br>Valid extensions are PDF, DOC, DOCX, XLS, XLSX, JPG, JPEG, PNG".html_safe} %>
     <p class="govuk-body" id="content_asset_file_size"></p>
   </div>
-
 <div class="govuk-grid-row">
 <div class="govuk-grid-column-one-half">
-  <%= form.submit('Submit', :class => "govuk-button", disabled: true) %>
+  <%= form.govuk_submit "Submit" %>
 </div>
 </div>
 

--- a/app/views/content_assets/new.html.erb
+++ b/app/views/content_assets/new.html.erb
@@ -1,4 +1,4 @@
-<h1  class="govuk-heading-l">New Content Asset</h1>
+<h1  class="govuk-heading-l">New content asset</h1>
 
 <%= render 'form', content_asset: @content_asset %>
 

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -104,14 +104,12 @@ if (stickyMenu) {
   }
 }
 
-$('#content_asset_asset_file').on('change', function() {
+$('.govuk-file-upload').on('change', function() {
   const size = (this.files[0].size / 1024 /1024).toFixed(2);
   var $submit = $('input[type="submit"]');
-  $submit.prop('disabled', true);
   if (size > 2) {
     $("#content_asset_file_size").html('<b>' + 'This file size is too large: ' + size + " MB" + '</b>');
   } else {
-    $submit.prop('disabled', false);
     $("#content_asset_file_size").html('<b>' + 'This file size is: ' + size + " MB" + '</b>');
   } 
 });

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -57,8 +57,13 @@ en:
       models:
         content_asset:
           attributes:
+            title:
+              blank: must not be blank
+            alt_text:
+              blank: must not be blank
             asset_file:
-              invalid_extension:  "invalid extension. Valid extensions are PDF, DOC, DOCX, XLS, XLSX, JPG, JPEG, PNG"
+              blank: must not be blank
+              invalid_extension:  has an invalid extension.
         user:
           attributes:
             email:

--- a/public/googled60dcae7f0841d08.html
+++ b/public/googled60dcae7f0841d08.html
@@ -1,0 +1,1 @@
+google-site-verification: googled60dcae7f0841d08.html

--- a/spec/features/content_assets_spec.rb
+++ b/spec/features/content_assets_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "New content assets page", type: :feature do
   scenario "should not have any accessibility errors" do
     sign_in create :admin
     visit "/cms/assets/new"
-  
+
     expect(page).to be_axe_clean
   end
 end

--- a/spec/features/content_assets_spec.rb
+++ b/spec/features/content_assets_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.feature "New content assets page", type: :feature do
+  scenario "should not have any accessibility errors" do
+    sign_in create :admin
+    visit "/cms/assets/new"
+  
+    expect(page).to be_axe_clean
+  end
+end

--- a/spec/models/content_asset_spec.rb
+++ b/spec/models/content_asset_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ContentAsset, type: :model do
     it "needs a valid extension" do
       content_asset.asset_file.attach(io: File.open("spec/fixtures/sample.jpeg"), filename: "sample.xxx", content_type: "image/jpeg")
       content_asset.validate
-      expect(content_asset.errors[:asset_file]).to include("invalid extension. Valid extensions are PDF, DOC, DOCX, XLS, XLSX, JPG, JPEG, PNG")
+      expect(content_asset.errors[:asset_file]).to include("has an invalid extension.")
     end
   end
 
@@ -55,13 +55,13 @@ RSpec.describe ContentAsset, type: :model do
       content_asset.validate
     end
     it "requires a title" do
-      expect(content_asset.errors[:title]).to include("can't be blank")
+      expect(content_asset.errors[:title]).to include("must not be blank")
     end
     it "requires an asset to be uploaded" do
-      expect(content_asset.errors[:asset_file]).to include("can't be blank")
+      expect(content_asset.errors[:asset_file]).to include("must not be blank")
     end
     it "requires an alt text for the asset" do
-      expect(content_asset.errors[:alt_text]).to include("can't be blank")
+      expect(content_asset.errors[:alt_text]).to include("must not be blank")
     end
   end
 end


### PR DESCRIPTION
### Context
[HFEYP-497](https://dfedigital.atlassian.net/browse/HFEYP-497)
[HFEYP-501](https://dfedigital.atlassian.net/browse/HFEYP-501)

### Changes proposed in this pull request

Updated the assets form to use the govuk formbuilder, which should be more accessible (if not, we should investigate why). This added a label and hint to the asset file input.  As such I updated the error message for the file extension to just indicated the invalid extension as the valid extensions are now listed in the hint.

I considered using the govuk form builder for the error summary, which looks much nicer, but it has the same issue with only showing one error per field that we have with users.  It would be nice to build off the govuk form builder's error summary component and update it to show all the errors for the fields.

For 501, the google verification file has been placed in the public folder, so it can be verified by google.

### Guidance to review

