### PR TITLE
Move notice display, so it shows properly

### DIFF
--- a/app/views/admin/_notice.html.haml
+++ b/app/views/admin/_notice.html.haml
@@ -1,5 +1,0 @@
-- if notice
-  .govuk-success-summary.banner-with-tick{aria: {labelledby: "success-message"}, tabindex: "-1", role: "alert"}
-    .govuk-success-summary__title
-      %h2.govuk-heading-m#success-message
-        = notice.html_safe

--- a/app/views/admin/users/index.html.haml
+++ b/app/views/admin/users/index.html.haml
@@ -1,5 +1,3 @@
-= render "admin/notice"
-
 = link_to "Back", content_pages_path, class: 'govuk-back-link'
 
 %h1.govuk-heading-xl

--- a/app/views/content_assets/index.html.erb
+++ b/app/views/content_assets/index.html.erb
@@ -1,7 +1,3 @@
-<div class="govuk-error-message" role="alert" aria-labelledby="error-summary-heading">
-  <span id="notice"><%= notice %></span>
-</div>
-
 <h1  class="govuk-heading-l">Assets</h1>
 
 <%= link_to 'Add Asset', new_content_asset_path, :class => "govuk-link" %>

--- a/app/views/content_assets/show.html.erb
+++ b/app/views/content_assets/show.html.erb
@@ -1,21 +1,14 @@
-<p id="notice"><%= notice %></p>
+<h1 class="govuk-heading-xl"><%= @content_asset.title %></h1>
+<% if @content_asset.asset_file.attached? %>
+  <%= image_tag(url_for(@content_asset.asset_file), :alt_text => @content_asset.alt_text) %>
+  <div id='asset-details'>
+  <h3>Asset Details</h3>
+  <%= render partial: 'clipboard', locals: { clipboard_content: polymorphic_url(@content_asset.asset_file) } %>
+  </div>
+<% end %>
 
-<main class="govuk-main-wrapper " id="main-content" role="main">
-  <h1 class="govuk-heading-xl"><%= @content_asset.title %></h1>
-
-
-  <% if @content_asset.asset_file.attached? %>
-    <%= image_tag(url_for(@content_asset.asset_file), :alt_text => @content_asset.alt_text) %>
-    <div id='asset-details'>
-    <h3>Asset Details</h3>
-    <%= render partial: 'clipboard', locals: { clipboard_content: polymorphic_url(@content_asset.asset_file) } %>
-    </div>
-  <% end %>
-  
-  <%= link_to 'Edit', edit_content_asset_path(@content_asset), { :class => "govuk-link" } %> |
-  <%= link_to 'Back', content_assets_path, { :class => "govuk-link" } %>
-
-</main>
+<%= link_to 'Edit', edit_content_asset_path(@content_asset), { :class => "govuk-link" } %> |
+<%= link_to 'Back', content_assets_path, { :class => "govuk-link" } %>
 
 
 

--- a/app/views/layouts/_notice.html.haml
+++ b/app/views/layouts/_notice.html.haml
@@ -1,0 +1,5 @@
+- if notice
+  .govuk-success-summary.banner-with-tick{aria: {labelledby: "success-message"}, data: {qa: "success-message"}, tabindex: "-1", role: "alert"}
+    .govuk-success-summary__title
+      %h2.govuk-heading-m#success-message
+        = notice.html_safe

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -82,6 +82,7 @@
 
         <div class="govuk-grid-column-two-thirds">
           <div id="main-content" class="app-content gem-c-govspeak">
+            <%= render 'layouts/notice' %>
             <%= yield %>
             <% if @page.navigation %>
               <nav class="gem-c-pagination" role="navigation" aria-label="Pagination">

--- a/app/views/layouts/cms.html.erb
+++ b/app/views/layouts/cms.html.erb
@@ -63,6 +63,7 @@
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" role="main" id="main-content" >
+        <%= render 'layouts/notice' %>
         <%= yield %>
       </main>
     </div>

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -53,6 +53,7 @@
 
 <div class="govuk-width-container">
   <main class="govuk-main-wrapper" role="main" id="main-content">
+    <%= render 'layouts/notice' %>
     <%= yield %>
   </main>
 </div>

--- a/app/views/layouts/landing_page_layout.html.erb
+++ b/app/views/layouts/landing_page_layout.html.erb
@@ -72,6 +72,7 @@
 </aside>
 
 <main class="eyfs-wrapper" role="main">
+  <%= render 'layouts/notice' %>
   <%= yield %>
 </main>
 


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
Previously the notice was rendered haphazardly.
A notice should be displayed on the first response from
it being set in the controller, so should be in the layout.

We have 4 primary layouts right now:

* CMS
* Errors
* Application
* Landing Page

### Guidance to review

As the the cookie banner notice logic is now use in general, I updated the `data-qa` label to just say `success-message` rather than `cookie-banner-success-message`
