### PR TITLE
Format notice dev

### DIFF
--- a/app/views/layouts/landing_page_layout.html.erb
+++ b/app/views/layouts/landing_page_layout.html.erb
@@ -61,6 +61,8 @@
 
 <aside title="Get alerts">
   <div class="govuk-width-container govuk-!-margin-top-4">
+    <%= render 'layouts/notice' %>
+
     <div class="eyfs-signup-link--with-background-and-border">
         <svg class="eyfs-signup-link__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
           <path d="M15.137 3.945c-.644-.374-1.042-1.07-1.041-1.82v-.003c.001-1.172-.938-2.122-2.096-2.122s-2.097.95-2.097 2.122v.003c.001.751-.396 1.446-1.041 1.82-4.667 2.712-1.985 11.715-6.862 13.306v1.749h20v-1.749c-4.877-1.591-2.195-10.594-6.863-13.306zm-3.137-2.945c.552 0 1 .449 1 1 0 .552-.448 1-1 1s-1-.448-1-1c0-.551.448-1 1-1zm3 20c0 1.598-1.392 3-2.971 3s-3.029-1.402-3.029-3h6z"/>
@@ -72,7 +74,6 @@
 </aside>
 
 <main class="eyfs-wrapper" role="main">
-  <%= render 'layouts/notice' %>
   <%= yield %>
 </main>
 


### PR DESCRIPTION
### Context
The banner saying 'Your cookie settings were saved' is now formatted properly

### Changes proposed in this pull request

### Guidance to review
Clear cookies, visit the home page, accept cookies, check that the banner looks ok

![Screenshot 2021-07-21 at 13 20 16](https://user-images.githubusercontent.com/3352035/126487575-45392a52-a553-4d6b-ba97-e02011b55f82.png)


