### PR TITLE
Only show successful cookie setting message when set from cookies page

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -20,6 +20,8 @@ private
 
   def set_cookie_pref
     cookies[:track_analytics] = { value: track_analytics, expires: 6.months.from_now }
-    flash[:notice] = t(:preferences_saved_html, return_url: helpers.root_path, scope: :settings)
+    if params.fetch(:notify_if_successful, false)
+      flash[:notice] = t(:preferences_saved_html, return_url: helpers.root_path, scope: :settings)
+    end
   end
 end

--- a/app/views/settings/_cookie_form.html.erb
+++ b/app/views/settings/_cookie_form.html.erb
@@ -7,6 +7,7 @@
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
         Do you want to accept analytics cookies?
       </legend>
+      <%= form.hidden_field :notify_if_successful, value: true %>
       <div class="govuk-radios govuk-radios--inline">
         <div class="govuk-radios__item">
           <%= form.text_field :track_analytics, id: "analytics-cookies", type: "radio", class: "govuk-radios__input", value: "Yes", checked: (cookies[:track_analytics] == "Yes") %>


### PR DESCRIPTION
### Context
[HFEYP-508](https://dfedigital.atlassian.net/browse/HFEYP-508)

### Changes proposed in this pull request
Fixing the banner notice issue caused previously delayed notices to show up immediately.  As we are only interested in notifying users who explicitly set their cookie preferences while on the cookies page, and do not care to keep those who set them otherwise informed, we will only set the message when requested which can be done using a hidden field on the form submitting the request.

### Guidance to review

