### PR TITLE
Remove unecessary links to 'Refresh' and 'Back'

### DIFF
--- a/app/views/content_blocks/edit.html.erb
+++ b/app/views/content_blocks/edit.html.erb
@@ -1,5 +1,2 @@
 <h1 class="govuk-heading-l">Edit a Block</h1>
 <%= render 'form', content_block: @content_block %>
-
-<%= link_to 'Refresh', edit_content_block_path(@content_block), { :class => "govuk-link" } %>|
-<%= link_to 'Back', content_block_path %>

--- a/app/views/content_blocks/edit.html.erb
+++ b/app/views/content_blocks/edit.html.erb
@@ -1,2 +1,2 @@
-<h1 class="govuk-heading-l">Edit a Block</h1>
+<h1 class="govuk-heading-l">Edit a block</h1>
 <%= render 'form', content_block: @content_block %>


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/HFEYP-506

### Changes proposed in this pull request
A back button on the edit Content Block page was causing a 404. We don't need this button.

Also, the refresh link reverts the editor's changes without warning and anyway, duplicates the Cancel link

### Guidance to review
Check that the Back and Refresh links are no longer on the edit content block page
