### PR TITLE
Add a content block for this content

### DIFF
--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -46,10 +46,7 @@
       <div class="govuk-grid-column-full">
         <%= render partial: 'layouts/show_links_to_children_of_page_with_title' %>
         <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-        <h2 class="govuk-heading-l">Other useful resources</h2>
-        <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/changes-to-the-early-years-foundation-stage-eyfs-framework/changes-to-the-early-years-foundation-stage-eyfs-framework">Changes to the early years foundation stage framework</a></p>
-        <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">Statutory framework for the early years foundation stage</a></p>
-        <p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/development-matters--2">Development Matters, non-statutory curriculum guidance for the early years foundation stage</a></p>
+        <%== insert_block('other_useful_resources') %>
       </div>
     </div>
   </div>

--- a/db/seeds/create_content_blocks.rb
+++ b/db/seeds/create_content_blocks.rb
@@ -1,14 +1,10 @@
 # rubocop:disable Layout/HeredocIndentation
 
 markdown_for_other_useful_resources = <<-MARKDOWN_FOR_OTHER_USERFUL_RESOURCES
-## Other useful resources
-[Changes to the early years foundation stage framework](https://www.gov.uk/government/publications/changes-to-the-early-years-foundation-stage-eyfs-framework/changes-to-the-early-years-foundation-stage-eyfs-framework)
-
-[Statutory framework for the early years foundation stage](https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2)
-
-[Development Matters, non-statutory curriculum guidance for the early years foundation stage ](https://www.gov.uk/government/publications/development-matters--2)
-
-
+<h2 class="govuk-heading-l">Other useful resources</h2>
+<p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/changes-to-the-early-years-foundation-stage-eyfs-framework/changes-to-the-early-years-foundation-stage-eyfs-framework">Changes to the early years foundation stage framework</a></p>
+<p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">Statutory framework for the early years foundation stage</a></p>
+<p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/development-matters--2">Development Matters, non-statutory curriculum guidance for the early years foundation stage</a></p>
 MARKDOWN_FOR_OTHER_USERFUL_RESOURCES
 
 unless ContentBlock.exists?(name: "other_useful_resources")


### PR DESCRIPTION
### Context
Create a Content Block for the 'Other useful resources' section of the landing page

https://dfedigital.atlassian.net/browse/HFEYP-119

### Changes proposed in this pull request
Add a content block with the name 'other_useful_resources' containing this markdown (actually html)

```
<h2 class="govuk-heading-l">Other useful resources</h2>
<p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/changes-to-the-early-years-foundation-stage-eyfs-framework/changes-to-the-early-years-foundation-stage-eyfs-framework">Changes to the early years foundation stage framework</a></p>
<p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">Statutory framework for the early years foundation stage</a></p>
<p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/development-matters--2">Development Matters, non-statutory curriculum guidance for the early years foundation stage</a></p>
```
 

### Guidance to review
Check that the 'Other useful resources' section of the landing page looks the same as it does on production 
