### PR TITLE
Add an id to the error div so that the link works

### DIFF
--- a/app/views/content_blocks/_form.html.erb
+++ b/app/views/content_blocks/_form.html.erb
@@ -12,7 +12,7 @@
              set its own id, and the GOVUKDesignSystemFormBuilder hijacks it -->
 
         <% markdown_class = 'govuk-form-group--error' if @content_block.errors[:markdown].count > 0 %>
-        <div class="govuk-form-group gem-c-govspeak govuk-form-group <%= markdown_class %>">
+        <div class="govuk-form-group gem-c-govspeak govuk-form-group <%= markdown_class %>" id="content-block-markdown-field-error">
           <label id="markdown-hint" for="markdown-editor" class="govuk-hint">
             Content - Markdown for the block
           </label>


### PR DESCRIPTION
### Context
509 - Clicking on the link to the 'Content must not be blank' message should redirect to that part of the form

### Changes proposed in this pull request
Just added an id to the error div

### Guidance to review
Create a new content block with not content. Click Save.  Then Click on the link to 'Content must not be blank' and verify that it redirects to that part of the form
