### PR TITLE
539 Card sizing alignment for mobile landscape

### DIFF
--- a/app/webpacker/styles/_cards.scss
+++ b/app/webpacker/styles/_cards.scss
@@ -89,10 +89,6 @@ $card-border-hover-color: #003078;
     .eyfs-card {
       margin-bottom: govuk-spacing(3);
     }
-
-    &:last-child .eyfs-card {
-      margin-bottom: 0;
-    }
   }
 
   .eyfs-card--feature {

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -35,7 +35,7 @@ GOOGLE_STATIC_DOMAINS = %w[fonts.gstatic.com www.gstatic.com *.hotjar.com].freez
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self, :https, *GOVUK_DOMAINS
   policy.font_src    :self, :https, *GOVUK_DOMAINS, *GOOGLE_STATIC_DOMAINS, :data
-  policy.frame_src   :self, *OPTIMIZE_DOMAINS
+  policy.frame_src   :self, *GOOGLE_ANALYTICS_DOMAINS, *OPTIMIZE_DOMAINS
   policy.img_src     :self,
                      *GOVUK_DOMAINS,
                      *S3_DOMAINS,


### PR DESCRIPTION
[HFEYP-539](https://dfedigital.atlassian.net/browse/HFEYP-539)

### Context
Height difference in cards for mobile landscape.

### Changes proposed in this pull request
Margin bottom of zero on last child was causing issue. Need to confirm with @tunde the purpose of the 0 margin and whether it's ok to remove in all cases or if we need to target specific use cases (i.e. width where there are two columns with cards side 
by side).  The issue (different heights) is still there when it reduces to a single column but I think it is done to minimize the space between sections. If we're ok with the additional space, then this solution should work.

### Guidance to review

Before:
![CleanShot 2021-08-13 at 12 32 06@2x](https://user-images.githubusercontent.com/6605/129353580-1cc29d4d-ee47-4b2c-9a40-101c9fada990.png)

After:
![CleanShot 2021-08-13 at 12 31 23@2x](https://user-images.githubusercontent.com/6605/129353966-cbe24bf1-564b-4dc0-89ad-e87d2982c5dc.png)
