### PR TITLE
User's first name and last name are mandatory.  Typo in title for edi…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
   enum role: ROLES.zip(ROLES).to_h
 
   validates :email, presence: true, uniqueness: true, if: :domain_check, format: { with: URI::MailTo::EMAIL_REGEXP, message: EMAIL_ERROR_MESSAGE }
+  validates :first_name, presence: true
+  validates :last_name, presence: true
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,8 +1,8 @@
 <%= form_with(model: [:admin, user], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
-  <%= form.govuk_error_summary order: %i[email password password_confirmation role] %>
+  <%= form.govuk_error_summary order: %i[email password password_confirmation role, first_name, last_name] %>
   <%= form.govuk_text_field :first_name, label: {text: "First name"} %>
   <%= form.govuk_text_field :last_name, label: {text: "Last name"} %>
-  <%= form.govuk_email_field :email, disabled: user.persisted? %>
+  <%= form.govuk_email_field :email, disabled: user.persisted?, label: {text: "Email"} %>
   <span class="govuk-fieldset tooltip">
     <%= form.govuk_password_field :password, placeholder: user.persisted? ? "********" : "", label: {text: "Password", id: "user-password-label"} do %>
       <%= t('password_hint.html') %>

--- a/app/views/content_pages/index.html.erb
+++ b/app/views/content_pages/index.html.erb
@@ -1,5 +1,4 @@
-<h1 class="govuk-heading-l">Edit pages</h1>
-
+<h1 class="govuk-heading-l">Pages</h1>
 <br/>
 
 <div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,10 @@ en:
               blank: Select an editor or administrator role type
             password_confirmation:
               confirmation: Password confirmation does not match password
+            first_name:
+              blank: First name must not be blank
+            last_name:
+              blank: Last name must not be blank
   settings:
     cookie-policy: Cookies
     preferences_saved_html: Your cookie settings were saved</br><a class='govuk-link' href='%{return_url}'>Go back to Help for early years providers</a>

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
     email { [Faker::Internet.user_name, %w[@digital.education.gov.uk @education.gov.uk].sample].join("") }
     password { "TestPassword!@12345" }
     role { "reader" }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
 
     factory :admin do
       role { "admin" }

--- a/spec/features/admin/user_admin_page_spec.rb
+++ b/spec/features/admin/user_admin_page_spec.rb
@@ -51,5 +51,35 @@ RSpec.feature "User administration", type: :feature do
       expect_within_table_row(2, ["J Jonah Jameson", "jjj@education.gov.uk", "Editor"])
       expect_within_table_row(3, ["Perry White", "pwhite@education.gov.uk", "Editor"])
     end
+
+    scenario "An admin user should not be able to create a new user without providing a first name" do
+      login_as(barbara)
+      visit new_admin_user_path(barbara)
+
+      fill_in "user-last-name-field", with: Faker::Name.last_name
+      fill_in "user-password-field", with: "WordyWord2021%%"
+      fill_in "user-password-confirmation-field", with: "WordyWord2021%%"
+      choose("user-role-editor-field", visible: false)
+      fill_in "user-email-field", with: "buzzard@education.gov.uk"
+
+      click_button "Save"
+
+      expect(page).to have_text("First name must not be blank")
+    end
+
+    scenario "An admin user should not be able to create a new user without providing a last name" do
+      login_as(barbara)
+      visit new_admin_user_path(barbara)
+
+      fill_in "user-first-name-field", with: Faker::Name.first_name
+      fill_in "user-password-field", with: "WordyWord2021%%"
+      fill_in "user-password-confirmation-field", with: "WordyWord2021%%"
+      choose("user-role-editor-field", visible: false)
+      fill_in "user-email-field", with: "moggy@education.gov.uk"
+
+      click_button "Save"
+
+      expect(page).to have_text("Last name must not be blank")
+    end
   end
 end


### PR DESCRIPTION
### Context
https://dfedigital.atlassian.net/browse/HFEYP-536 - One word change in a title
https://dfedigital.atlassian.net/browse/HFEYP-534 - first and last name of user is now mandatory

### Changes proposed in this pull request
The first and last name of a user is now mandatory

### Guidance to review
Try adding a new user without a first name, it should cause an error
