### PR TITLE
Fallback to initial content block values

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -20,9 +20,22 @@ module ContentHelper
     params[:slug] == page.slug || params[:section] == page.slug
   end
 
+  # First try to find the ContentBlock in the database. Fallback to a
+  # value from the locale file, or failing that to a fixed text warning
   def insert_block(block_name)
     block = ContentBlock.find_by_name(block_name)
-    html_to_use = block ? block.markdown : "Error - block not found"
+
+    html_to_use = nil
+
+    if block
+      html_to_use = block.markdown
+    else
+      begin
+        html_to_use = t("content-block-content.#{block_name}", raise: true)
+      rescue I18n::MissingTranslationData
+        html_to_use = "Error - content block not found"
+      end
+    end
 
     GovspeakToHTML.new.translate_markdown html_to_use
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,12 +90,12 @@ en:
               blank: Select an editor or administrator role type
             password_confirmation:
               confirmation: Password confirmation does not match password
-            first_name:
-              blank: First name must not be blank
-            last_name:
-              blank: Last name must not be blank
   settings:
     cookie-policy: Cookies
     preferences_saved_html: Your cookie settings were saved</br><a class='govuk-link' href='%{return_url}'>Go back to Help for early years providers</a>
+
+  content-block-content:
+    landing-page-introduction: <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">Help for early years providers</h1><p class="govuk-body-l">The Early Years Foundation Stage (EYFS) has changed. Find guidance and practical support to help you with the changes</p><p class="govuk-body-l">These resources are for childminders, nursery leaders and pre-school practitioners.</p>
+    other_useful_resources: <h2 class="govuk-heading-l">Other useful resources</h2><p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/changes-to-the-early-years-foundation-stage-eyfs-framework/changes-to-the-early-years-foundation-stage-eyfs-framework">Changes to the early years foundation stage framework</a></p><p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/early-years-foundation-stage-framework--2">Statutory framework for the early years foundation stage</a></p><p class="govuk-body"><a class="govuk-link" href="https://www.gov.uk/government/publications/development-matters--2">Development Matters, non-statutory curriculum guidance for the early years foundation stage</a></p>
 
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,10 @@ en:
               blank: Select an editor or administrator role type
             password_confirmation:
               confirmation: Password confirmation does not match password
+            first_name:
+              blank: First name must not be blank
+            last_name:
+              blank: Last name must not be blank
   settings:
     cookie-policy: Cookies
     preferences_saved_html: Your cookie settings were saved</br><a class='govuk-link' href='%{return_url}'>Go back to Help for early years providers</a>

--- a/spec/features/content_block_spec.rb
+++ b/spec/features/content_block_spec.rb
@@ -84,4 +84,11 @@ RSpec.feature "View content blocks", type: :feature do
       # expect { visit "cms/blocks" }.to raise_error( Pundit::NotAuthorizedError )
     end
   end
+
+  describe "Falling back to an initial version of ContentBlock text" do
+    scenario "If the ContentBlock is undefined in the database, its initial value should still be set by the locale (en.yml)" do
+      visit("/")
+      expect(page.body).to include("Find guidance and practical support to help you with the changes")
+    end
+  end
 end


### PR DESCRIPTION
### Context
Provides fallback values for ContentBlocks if the normal database definitions are not found

### Changes proposed in this pull request
The locale file en.yml now has definitions for ContentBlock content for 'landing-page-introduction' and 'other_useful_resources'.   Programmers would have to add new definitions as they add new mentions of
content block titles in the view code.

I have not yet added content for the cookies, because its 3880 characters long.   


### Guidance to review
Remove the other_useful_resources ContentBlock from the database and check that the text from en.yml is still returned
