### PR TITLE
Add youtube to frame-src content security policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -24,6 +24,9 @@ GOOGLE_ANALYTICS_DOMAINS = %w[www.google-analytics.com
                               ssl.google-analytics.com
                               stats.g.doubleclick.net
                               www.googletagmanager.com
+                              *.ytimg.com
+                              www.youtube.com
+                              www.youtube-nocookie.com
                               *.hotjar.com].freeze
 
 OPTIMIZE_DOMAINS = %w[www.googleoptimize.com


### PR DESCRIPTION
### Context

Hot fix applied to release/v1.7.0 (and then release/v1.8.0) - Youtube endpoints appear to have changed between release 1.6 and 1.7, requiring these additions to the content security policy

### Changes proposed in this pull request
Add the following to the content security policy:
```
*.ytimg.com
www.youtube.com
www.youtube-nocookie.com
```

### Guidance to review

As before, you can check the policy with curl:
```
❯ curl -s -D - http://localhost:3000/communication-and-language -o /dev/null
HTTP/1.1 200 OK
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Permitted-Cross-Domain-Policies: none
Referrer-Policy: strict-origin-when-cross-origin
Content-Type: text/html; charset=utf-8
Vary: Accept,Accept-Encoding
ETag: W/"0851e9cbf4f978aa6a421fca9d13fc9c"
Cache-Control: max-age=0, private, must-revalidate
Content-Security-Policy: default-src https: 'self' *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk; img-src 'self' data: *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com assets.digital.cabinet-office.gov.uk lux.speedcurve.com; script-src 'self' *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com www.gstatic.com www.signin.service.gov.uk *.ytimg.com www.youtube.com www.youtube-nocookie.com hmrc-uk.digital.nuance.com 'unsafe-inline'; style-src 'self' *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk www.gstatic.com 'unsafe-inline'; font-src 'self' *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk data:; connect-src 'self' *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk www.google-analytics.com ssl.google-analytics.com stats.g.doubleclick.net www.googletagmanager.com www.tax.service.gov.uk hmrc-uk.digital.nuance.com gov.klick2contact.com www.signin.service.gov.uk; object-src 'none'; frame-src 'self' *.publishing.service.gov.uk *.www.gov.uk www.gov.uk *.dev.gov.uk www.youtube.com www.youtube-nocookie.com
Set-Cookie: _help_for_early_years_providers_session=4QJ0l5th7CmdxvlBLO1MhiyaBUIeotNNrC95SAJz06kbBmfIlHW46ua8aLOvLmIgNoaEtILrFImZRCFfq9BuoUIsf%2FELXjgwdH0A6iGsYZLNMYENd%2Bu1yVgg6oAzHKutD2BKsXPuCUvMVKatfN%2F2BtJ6DsUvIUrgfVsKFv7riTtLBxCzsUx2I46b32eORmduRw7LsILgJ9Rs7YTyumJFEXsqgaA58lGQ%2F7A%2B5VMv6XrtIVuC%2BjTj%2FI7llgwlnYpEpucPMiT0tNYLw2X%2FnSNufQlQxGKWVQdPadrKFqfMY6UVQCq2YquPyDu8pATd85o%3D--e6XhjTSrRKrRk625--iUqyGthlG%2FARdxmzvImmMA%3D%3D; path=/; HttpOnly
X-Request-Id: 807d8632-fb58-439d-bf2f-7b52774c962f
X-Runtime: 3.674310
Transfer-Encoding: chunked
```