### PR TITLE
use govuk-label instead of govuk-hint

### DIFF
--- a/app/views/content_blocks/_form.html.erb
+++ b/app/views/content_blocks/_form.html.erb
@@ -13,7 +13,7 @@
 
         <% markdown_class = 'govuk-form-group--error' if @content_block.errors[:markdown].count > 0 %>
         <div class="govuk-form-group gem-c-govspeak govuk-form-group <%= markdown_class %>" id="content-block-markdown-field-error">
-          <label id="markdown-hint" for="markdown-editor" class="govuk-hint">
+          <label id="markdown-hint" for="markdown-editor" class="govuk-label">
             Content - Markdown for the block
           </label>
           <% if @content_block&.errors[:markdown].count > 0 %>

--- a/app/views/content_pages/_form.html.erb
+++ b/app/views/content_pages/_form.html.erb
@@ -24,7 +24,7 @@
           </div>
 
           <div class="govuk-form-group gem-c-govspeak">
-            <label id="markdown-hint" for="markdown-editor" class="govuk-hint">
+            <label id="markdown-hint" for="markdown-editor" class="govuk-label">
               Content
             </label>
             <%= form.text_area :markdown, :id => 'markdown-editor', :rows => 20, :cols => 35,  :class => "govuk-textarea" %>


### PR DESCRIPTION
### Context
Minor bug: https://dfedigital.atlassian.net/jira/software/projects/HFEYP/boards/83?selectedIssue=HFEYP-492

### Changes proposed in this pull request
- change class from hint to label so text is normal colour

### Guidance to review
- check text headings for fields are black in cms (pages and blocks)

