### PR TITLE
ContentPageVersion validates title for format

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -26,7 +26,7 @@ class ContentController < ApplicationController
   def index
     @featured_pages = ContentPage.where(title: FEATURED_PAGE_TITLES).order_by_position
     # Don't show featured pages in the cards
-    @content_pages = ContentPage.top_level.order_by_position - @featured_pages
+    @content_pages = ContentPage.top_level.published.order_by_position - @featured_pages
 
     respond_to do |format|
       format.html { render "index#{variant}", layout: "landing_page_layout" }

--- a/app/models/content_page_version.rb
+++ b/app/models/content_page_version.rb
@@ -6,6 +6,9 @@ class ContentPageVersion < ApplicationRecord
   belongs_to :content_page
 
   validates :markdown, presence: true
+  validates :title, presence: true
+
+  validates :title, format: { with: ContentPage::ONLY_ALPHA_NUMERIC_COMMA_HYPHEN_SPACE_AND_ROUND_BRACES, message: ContentPage::TITLE_FORMAT_ERROR_MESSAGE }
 
   def navigation
     true

--- a/app/views/content/index_v1.html.erb
+++ b/app/views/content/index_v1.html.erb
@@ -37,7 +37,7 @@
 
     <!-- Featured Pages Section -->
     <div class="govuk-width-container">
-    <% @featured_pages.each do |featured_page| %>
+    <% @featured_pages.published.each do |featured_page| %>
       <h2 class="govuk-heading-l govuk-!-padding-top-5"><%= featured_page.title %></h2>
       <ul class="govuk-grid-row eyfs-card-group">
       <% if featured_page.title != "Safeguarding and welfare" %>

--- a/app/views/content_page_versions/_form.html.erb
+++ b/app/views/content_page_versions/_form.html.erb
@@ -2,25 +2,29 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       <p class="govuk-heading-m">Details</p>
-      <%= form_with(model: @content_page_version, url: [@content_page_version.content_page, @content_page_version], local: true) do |form| %>
+      <%= form_with(model: [:content_page, @content_page_version], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
         <fieldset class="govuk-fieldset">
-          <div class="govuk-form-group">
-            <label class="govuk-label" for="Heading">
-              <%= form.label :title, "Heading" %>
-            </label>
-            <%= form.text_field :title, :class => 'govuk-input govuk-!-width-three-quarters', :disabled => true %>
-          </div>
+          <%= form.govuk_error_summary order: %i[title markdown]  %>
 
+          <%= form.govuk_text_field :title, label: {text: "Heading"}, :class => 'govuk-input govuk-!-width-three-quarters'%>
+
+          <!-- This text_area is not rendered with gov_text_field because it needs to
+               set its own id, and the GOVUKDesignSystemFormBuilder hijacks it -->
           <div class="govuk-form-group gem-c-govspeak">
-            <label id="markdown-hint" for="markdown-editor" class="govuk-hint">
+            <label id="markdown-hint" for="markdown-editor" class="govuk-label">
               Content
             </label>
-            <%= form.text_area :markdown, :id => 'markdown-editor', :rows => 20, :cols => 35,  :class => "govuk-textarea" %>
+            <% if @content_page_version&.errors[:markdown].count > 0 %>
+              <span class="govuk-error-message"><%= @content_page_version.errors[:markdown][0] %></span>
+            <% end %>
+            <% text_area_class = (@content_page_version.errors[:markdown].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
+
+            <%= form.text_area :markdown, :id => 'markdown-editor', :rows => 20, :cols => 35,  :class => text_area_class %>
           </div>
 
           <% if action_name === "edit" || action_name === "new" || action_name === "update" %>
             <div class="fixed-footer">
-              <%= form.submit class: "govuk-button", value: "Save as draft" %>
+              <%= form.govuk_submit "Save as draft" %>
               <%= link_to 'Cancel', edit_content_page_content_page_version_path(@content_page_version.content_page, @content_page_version), :data => {:confirm => "Are you sure you want to undo your changes ?", :class => "govuk-link"}%> |
               <%= link_to 'Back', content_pages_path, :data => {:confirm => "Any changes will be lost, are you sure ?", :class => "govuk-link"}%>
             </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -88,6 +88,13 @@ en:
             position:
               blank: Position must not be blank
               taken: Position is already taken
+        content_page_version:
+          attributes:
+            title:
+              blank: Heading must not be blank
+              format: "Heading should only contain alphabetic, numeric and -#{ContentPage::CHARS_TO_OMIT_FROM_SLUG}"
+            markdown:
+              blank: Content must not be blank
         content_asset:
           attributes:
             title:


### PR DESCRIPTION
### Context
Second attempt - ContentPageVersion edit form is now validated

### Changes proposed in this pull request
The title and content is now mandatory and red error messages are shown
Also the format of the title is validated using the same rules as for ContentPages

### Guidance to review
Edit a draft, submit without heading or content, verify that error messages appear
Check that headings containing @&@&($$& cause validation errors
