### PR TITLE
Create feature flag for support articles

### DIFF
--- a/app/services/feature.rb
+++ b/app/services/feature.rb
@@ -1,0 +1,10 @@
+class Feature
+  def self.enabled?(feature_name)
+    case feature_name.to_sym
+    when :support_articles
+      !Rails.env.production?
+    else
+      true
+    end
+  end
+end

--- a/app/views/layouts/cms.html.erb
+++ b/app/views/layouts/cms.html.erb
@@ -48,7 +48,7 @@
               <%= nav_link_to(title: "Admin", path: admin_users_path) if current_user.admin? %>
               <%= nav_link_to(title: "Blocks", path: content_blocks_path) if current_user.admin? %>
               <%= nav_link_to(title: "Pages", path: content_pages_path) %>
-              <%= nav_link_to(title: "Articles", path: admin_articles_path) %>
+              <%= nav_link_to(title: "Articles", path: admin_articles_path) if Feature.enabled?(:support_articles) %>
               <%= nav_link_to(title: "Assets", path: content_assets_path) %>
               <li class="govuk-header__navigation-item">
                 <%= link_to "See the site", "/", class: "govuk-header__link" %>


### PR DESCRIPTION
### Context

Need to hide articles in release

### Changes proposed in this pull request
A simple feature flag for support articles, hides articles when the Rails environment is not production.

Currently TEST, PRE-PROD and PROD spaces all use the production Rails environment.

DEV space uses `deployed_development` as the environment, so feature will be enabled in those spaces

### Guidance to review

