### PR TITLE
Update to use Personal Access Token with gh.cr

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -41,8 +41,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ebrett
+          password: ${{ secrets.GHCR_PERSONAL_TOKEN }}
 
       - name: Build and push docker image from builder target
         uses: docker/build-push-action@v2


### PR DESCRIPTION
## Ticket and context

No ticket - fixing an issue with review apps not working when triggered by Dependabot pull request.  According to https://github.community/t/cant-authenticate-with-actions-token-for-pr-event/170752/23 
a personal access token is required in this case.  

## Tech review

Added secret GHCR_PERSONAL_TOKEN which is tied to my GitHub account `ebrett` - set to expire in 90 days so we can review whether this is still required at that time.

