### PR TITLE
[HFEYP-621] Hide support articles on the landing page if feature not enabled

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   include Pundit
 
   def check
-    render json: { status: "OK", version: release_version, sha: ENV["SHA"], environment: Rails.env }, status: :ok
+    render json: { status: "OK", version: release_version, sha: ENV["SHA"], environment: Rails.env, features: Rails.configuration.x.features }, status: :ok
   end
 
   def not_found

--- a/app/services/feature.rb
+++ b/app/services/feature.rb
@@ -2,7 +2,7 @@ class Feature
   def self.enabled?(feature_name)
     case feature_name.to_sym
     when :support_articles
-      !Rails.env.production?
+      Rails.configuration.x.features.support_articles == "enabled"
     else
       true
     end

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -32,7 +32,7 @@
         <% end %>
       </ul>
 
-      <%- if Feature.enabled?(:support_articles) %>
+      <% if Feature.enabled?(:support_articles) %>
         <h2 id="get-support-and-guidance" class="govuk-heading-l eyfs-top-nav-anchors">Get support and guidance</h2>
         <ul class="govuk-grid-row eyfs-card-group">
             <li class="govuk-grid-column-one-half eyfs-card-group__item">

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -32,19 +32,21 @@
         <% end %>
       </ul>
 
-      <h2 id="get-support-and-guidance" class="govuk-heading-l eyfs-top-nav-anchors">Get support and guidance</h2>
-      <ul class="govuk-grid-row eyfs-card-group">
-          <li class="govuk-grid-column-one-half eyfs-card-group__item">
-            <div class="eyfs-card eyfs-card--clickable eyfs-card--link">
-              <div class="eyfs-card__content">
-                <a class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold govuk-link--no-visited-state" href="/articles">Support articles</a>
-                <svg class="eyfs-card--icon" width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#1D70B8" stroke-width="2"/>
-                </svg>
+      <%- if Feature.enabled?(:support_articles) %>
+        <h2 id="get-support-and-guidance" class="govuk-heading-l eyfs-top-nav-anchors">Get support and guidance</h2>
+        <ul class="govuk-grid-row eyfs-card-group">
+            <li class="govuk-grid-column-one-half eyfs-card-group__item">
+              <div class="eyfs-card eyfs-card--clickable eyfs-card--link">
+                <div class="eyfs-card__content">
+                  <a class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold govuk-link--no-visited-state" href="/articles">Support articles</a>
+                  <svg class="eyfs-card--icon" width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#1D70B8" stroke-width="2"/>
+                  </svg>
+                </div>
               </div>
-            </div>
-          </li>
-      </ul>
+            </li>
+        </ul>
+      <% end %>
     </div>
   </div>
   <!--End of cards section-->

--- a/app/views/layouts/_top_navigation_menu.html.erb
+++ b/app/views/layouts/_top_navigation_menu.html.erb
@@ -3,9 +3,11 @@
     <ul class="eyfs-top-nav-group">
       <li><a class="eyfs-top-nav__link govuk-link govuk-link--no-visited-state active" href="#">Home</a><li>
       <li><a class="eyfs-top-nav__link govuk-link govuk-link--no-visited-state" href="#areas-of-learning" >Areas of learning</a><li>
-      <li><a class="eyfs-top-nav__link govuk-link govuk-link--no-visited-state" href="#get-support-and-guidance" >Get support</a><li>
-      <% @featured_pages.each do |featured_page| %>
-        <li><a class="eyfs-top-nav__link govuk-link govuk-link--no-visited-state" href="#<%=featured_page.slug%>" ><%= ContentController::FEATURED_PAGE_HASH[featured_page.title] %></a><li>
+      <% if Feature.enabled?(:support_articles) %>
+        <li><a class="eyfs-top-nav__link govuk-link govuk-link--no-visited-state" href="#get-support-and-guidance" >Get support</a><li>
+        <% @featured_pages.each do |featured_page| %>
+          <li><a class="eyfs-top-nav__link govuk-link govuk-link--no-visited-state" href="#<%=featured_page.slug%>" ><%= ContentController::FEATURED_PAGE_HASH[featured_page.title] %></a><li>
+        <% end %>
       <% end %>
     </ul>
   </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,6 @@ module GovukRailsBoilerplate
     config.space = ENV.fetch( 'DOMAIN', "eyfs-dev" ).split(".").first
 
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', 'content', '*.{rb,yml}').to_s]
+    config.x.features.support_articles = ENV['SUPPORT_ARTICLES'].presence
   end
 end


### PR DESCRIPTION
## Ticket and context

[HFEYP-621](https://dfedigital.atlassian.net/browse/HFEYP-621)

You can also now set an ENV var to enable a feature

`cf set-env eyfs-cms-preprod SUPPORT_ARTICLES enabled`

### Code quality checks
- [ ] All commit messages are meaningful and true

