### PR TITLE
Hide support articles section unless there are published articles

### DIFF
--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -32,19 +32,21 @@
         <% end %>
       </ul>
 
-      <h2 id="get-support-and-guidance" class="govuk-heading-l eyfs-top-nav-anchors">Get support and guidance</h2>
-      <ul class="govuk-grid-row eyfs-card-group">
-          <li class="govuk-grid-column-one-half eyfs-card-group__item">
-            <div class="eyfs-card eyfs-card--clickable eyfs-card--link">
-              <div class="eyfs-card__content">
-                <a class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold govuk-link--no-visited-state" href="/articles">Support articles</a>
-                <svg class="eyfs-card--icon" width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#1D70B8" stroke-width="2"/>
-                </svg>
+      <% if Article.published.present? %>
+        <h2 id="get-support-and-guidance" class="govuk-heading-l eyfs-top-nav-anchors">Get support and guidance</h2>
+        <ul class="govuk-grid-row eyfs-card-group">
+            <li class="govuk-grid-column-one-half eyfs-card-group__item">
+              <div class="eyfs-card eyfs-card--clickable eyfs-card--link">
+                <div class="eyfs-card__content">
+                  <a class="govuk-link govuk-!-font-size-19 govuk-!-font-weight-bold govuk-link--no-visited-state" href="/articles">Support articles</a>
+                  <svg class="eyfs-card--icon" width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9 4.49992L20.0217 15.5213L9 26.5427" stroke="#1D70B8" stroke-width="2"/>
+                  </svg>
+                </div>
               </div>
-            </div>
-          </li>
-      </ul>
+            </li>
+        </ul>
+      <% end %>
     </div>
   </div>
   <!--End of cards section-->

--- a/spec/requests/content_request_spec.rb
+++ b/spec/requests/content_request_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Contents", type: :request do
   end
 
   describe "GET /" do
+    let(:article_section_link) { html_document.xpath('//a[contains(text(),"Support articles")][@href="/articles"]') }
     it "renders the landing page / hub page" do
       get "/"
       expect(response).to be_successful
@@ -36,10 +37,18 @@ RSpec.describe "Contents", type: :request do
       expect(response.headers["Cache-Control"]).to eq("max-age=3600, public")
     end
 
-    xit "renders the desktop menu of content pages, two levels, in correct order" do
+    it "does not display an articles section" do
+      get root_path
+      expect(article_section_link).not_to be_present
     end
 
-    xit "renders the mobile menu of content pages, two levels, in correct order" do
+    context "with an article present" do
+      before { create :article, :published }
+
+      it "does display an articles section" do
+        get root_path
+        expect(article_section_link).to be_present
+      end
     end
   end
 

--- a/spec/support/response_body_helpers.rb
+++ b/spec/support/response_body_helpers.rb
@@ -4,7 +4,12 @@ module ResponseBodyHelpers
   # Removes HTML escaping from response.body so for example `don&#39;t` in the page body is returned as `don't`
   # which is then easier to compare within a spec.
   def unescaped_response_body
-    CGI.unescapeHTML(response.body)
+    @unescaped_response_body ||= CGI.unescapeHTML(response.body)
+  end
+
+  # Returns the HTML in the response in a format (Nokogiri HTML document) that can be navigated via css and xpath.
+  def html_document
+    @html_document ||= Nokogiri::HTML(response.body)
   end
 end
 


### PR DESCRIPTION
## Ticket and context

Ticket: [HFEYP-621](https://dfedigital.atlassian.net/browse/HFEYP-621)

Note that the requirement has change. It is now to hide the section if there are no published articles, rather than using an environment configuration option.

### Code quality checks
- [ ] All commit messages are meaningful and true

### How can someone see it in review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. The articles section should not be present (unless someone has published an article)
3. Create an article in CMS and publish it
4. Return to the home page and the articles section should be present.
5. Return to CMS and unpublish all the articles there
6. Return to the home page and the articles section should be absent.