### PR TITLE
Add get help to improve your practice pages to seeding

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,6 +14,7 @@ end
 
 seed_content_pages_from "content_pages/communication_and_language.yml"
 seed_content_pages_from "content_pages/safeguarding_and_welfare.yml"
+seed_content_pages_from "content_pages/get_help_to_improve_your_practice.yml"
 
 Seeder.seed(:content_block)
 Seeder.seed(:user, name_method: :email) if Rails.application.credentials.test_password.present?

--- a/db/seeds/content_pages/get_help_to_improve_your_practice.yml
+++ b/db/seeds/content_pages/get_help_to_improve_your_practice.yml
@@ -1,0 +1,78 @@
+---
+get-help-to-improve-your-practice:
+  title: Get help to improve your practice
+  position: 8
+  is_published: true
+  markdown: |
+    The changes to the early years foundation stage (EYFS) framework include a number of updates to ways of working for early years practitioners.
+
+    Four guiding principles should shape practice in early years settings. These are:
+
+    - every child is a unique child, who is constantly learning and can be resilient, capable, confident and self-assured
+    - children learn to be strong and independent through positive relationships
+    - children learn and develop well in enabling environments with teaching and support from adults, who respond to their individual interests and needs and help them to build their learning over time. Children benefit from a strong partnership between practitioners and parents and/or carers.
+    - importance of learning and development. Children develop and learn at different rates. The framework covers the education and care of all children in early years provision, including children with special educational needs and disabilities (SEND).
+
+    In this section you will find guidance about:
+      
+    - Planning
+    - Reducing paperwork
+    - Identifying and supporting children with special educational needs and disability (SEND)
+    - Oral health
+    - Working in partnership with parents
+
+planning:
+  title: Planning
+  position: 1
+  parent: get-help-to-improve-your-practice
+  is_published: true
+  markdown: |
+    This content will cover how early years settings can plan their curriculum with some advice and best practices for planning.
+
+    The content could also cover key differences in the new EYFS, how to look at what they already cover with the children and where they may need to make changes.
+
+    The content will give advice for nursery leaders on providing staff training on the curriculum and identifying gaps in knowledge.
+
+reducing-paperwork:
+  title: Reducing paperwork
+  position: 2
+  parent: get-help-to-improve-your-practice
+  is_published: true
+  markdown: |
+    This content will cover why reducing paperwork is one of the key aims of the reforms. It will provide guidance on what should and shouldn’t be recorded, and how to make effective observations.
+
+    The content may contain some case studies from EYFS early adopters about how they’ve managed to balance making effective observations with reducing paperwork.
+
+    The content may include links to the relevant parts of Development Matters, information from Ofsted and other useful documents.
+
+identifying-and-supporting-children-with-special-educational-needs-and-disability:
+  title: Identifying and supporting children with special educational needs and disability
+  position: 3
+  parent: get-help-to-improve-your-practice
+  is_published: true
+  markdown: |
+    This content will cover a definition of special educational needs and disability (SEND) and advice on identifying children with SEND. It may also include examples or case studies to show how to support the early identification of SEND.
+
+    It may include examples or case studies showing how best to support children with SEND in your setting, how to work with parents of children with SEND and how to work with other authorities.
+
+    There will be links to useful resources including the SEND Code of Practice.
+
+working-in-partnership-with-parents:
+  title: Working in partnership with parents
+  position: 4
+  parent: get-help-to-improve-your-practice
+  is_published: true
+  markdown: |
+    This content will cover the importance and benefits of good relationships with parents, including how having good relationships with parents can help children settle in to a childcare setting.
+
+    It will also cover:
+
+    advice on how often to give updates
+    managing parental expectations
+    suggestions for the types of updates that could be given
+    advice on raising concerns with parents
+    This area has some overlap with reducing paperwork.
+
+    This content may contain case studies or advice from practitioners giving tips for working in partnership with parents.
+
+    We may also link to other helpful resources.

--- a/db/seeds/users.yml
+++ b/db/seeds/users.yml
@@ -1,4 +1,22 @@
 ---
+eyfr-test@digital.education.gov.uk:
+  first_name: Test
+  last_name: Admin
+  role: admin
+  password: <%= Rails.application.credentials.test_password || "#{SecureRandom.hex(8)}AA12!!" %>
+
+editor@education.gov.uk:
+  first_name: Fred
+  last_name: Bloggs
+  role: editor
+  password: <%= Rails.application.credentials.test_password || "#{SecureRandom.hex(8)}AA12!!" %>
+
+someone@education.gov.uk:
+  first_name: Jane
+  last_name: Doe
+  role: reader
+  password: <%= Rails.application.credentials.test_password || "#{SecureRandom.hex(8)}AA12!!" %>
+
 brett@education.gov.uk:
   first_name: Brett
   last_name: McHargue
@@ -33,16 +51,4 @@ peter.bromley@education.gov.uk:
   first_name: Peter
   last_name: Bromley
   role: admin
-  password: <%= Rails.application.credentials.test_password || "#{SecureRandom.hex(8)}AA12!!" %>
-
-editor@education.gov.uk:
-  first_name: Fred
-  last_name: Bloggs
-  role: editor
-  password: <%= Rails.application.credentials.test_password || "#{SecureRandom.hex(8)}AA12!!" %>
-
-someone@education.gov.uk:
-  first_name: Jane
-  last_name: Doe
-  role: reader
   password: <%= Rails.application.credentials.test_password || "#{SecureRandom.hex(8)}AA12!!" %>


### PR DESCRIPTION
Ticket: [HFEYP-643](https://dfedigital.atlassian.net/browse/HFEYP-643)

Currently only two parent content pages are seeded:

- Areas of learning
- Safeguarding and welfare

Data from previous seeding code that contains data for "Get help to improve your practice" and this should be added to the currently active system.

## Tech review

### Is there anything that the code reviewer should know?

The new content should be visible in test app

### Code quality checks
- [ ] All commit messages are meaningful and true

## Product review

### How can someone see it in review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. The section "Get help to improve your practice" should be present on the home page.
3. Click on links in the section to view page content.