### PR TITLE
HYEYP bug fix: Add padding to articles section heading

### DIFF
--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -37,7 +37,7 @@
 
     <% if Article.published.present? %>
       <div class="govuk-width-container">
-        <h2 id="get-support-and-guidance" class="govuk-heading-l eyfs-top-nav-anchors">Get support and guidance</h2>
+        <h2 id="get-support-and-guidance" class="govuk-heading-l govuk-!-padding-top-5 eyfs-top-nav-anchors">Get support and guidance</h2>
         <ul class="govuk-grid-row eyfs-card-group">
             <li class="govuk-grid-column-one-half eyfs-card-group__item">
               <div class="eyfs-card eyfs-card--clickable eyfs-card--link">


### PR DESCRIPTION
to match other headings above and below

## Ticket and context

Ticket: [HFEYP-563](https://dfedigital.atlassian.net/browse/HFEYP-563)

Prior to this change the section "Get support and guidance" was closer to the sections above it than the other section are to their immediate neighbour:

### Before change:

![get_support_without_padding_above](https://user-images.githubusercontent.com/213040/145799479-289d7cb2-0038-4d42-a9aa-a621d9215d5f.png)

With the addition of padding the section spacing matches the other sections:

### After change:

![get_support_with_padding_above](https://user-images.githubusercontent.com/213040/145799558-ab0f72ad-4f7a-4df3-941b-35370937b6d0.png)

