### PR TITLE
remove conditional so Articles link always displays

### DIFF
--- a/app/views/layouts/cms.html.erb
+++ b/app/views/layouts/cms.html.erb
@@ -47,7 +47,7 @@
               <%= nav_link_to(title: "Admin", path: admin_users_path) if current_user.admin? %>
               <%= nav_link_to(title: "Blocks", path: content_blocks_path) if current_user.admin? %>
               <%= nav_link_to(title: "Pages", path: content_pages_path) %>
-              <%= nav_link_to(title: "Articles", path: admin_articles_path) if Feature.enabled?(:support_articles) %>
+              <%= nav_link_to(title: "Articles", path: admin_articles_path) %>
               <%= nav_link_to(title: "Assets", path: content_assets_path) %>
               <li class="govuk-header__navigation-item">
                 <%= link_to "See the site", "/", class: "govuk-header__link" %>


### PR DESCRIPTION
## Ticket and context

Ticket: [HFEYP-645](https://dfedigital.atlassian.net/browse/HFEYP-645)
## Tech review
Articles always displays at the top of the screen across all environments.

### Code quality checks
- [x] All commit messages are meaningful and true

## Product review

### How can someone see it in review app?
1. Open this PR's CMS review app and go to `admin/users` [(link)](https://eyfs-cms-review-pr-527.london.cloudapps.digital/admin/users).
2. Log in (contact Rob Nichols for login details if you don't already have them)
3. The link to **Articles** should appear in the menu at the top of the page as shown below
![articles_link_present](https://user-images.githubusercontent.com/213040/148083651-f0dbf9a0-cbd8-4e1c-8479-52d293a0624e.png)
4. Click on the **Articles** and other navigation links, and the **Articles** should persist across the views.
