### PR TITLE
Hfeyp 597 remove back button on edit page screen

### DIFF
--- a/app/views/content_page_versions/_form.html.erb
+++ b/app/views/content_page_versions/_form.html.erb
@@ -26,8 +26,7 @@
           <% if action_name === "edit" || action_name === "new" || action_name === "update" %>
             <div class="fixed-footer">
               <%= form.govuk_submit "Save as draft" %>
-              <%= link_to 'Cancel', edit_content_page_content_page_version_path(@content_page_version.content_page, @content_page_version), :data => {:confirm => "Are you sure you want to undo your changes ?", :class => "govuk-link"}%> |
-              <%= link_to 'Back', versions_content_page_path(@content_page_version.content_page), :data => {:confirm => "Any changes will be lost, are you sure ?", :class => "govuk-link"}%>
+              <%= link_to 'Cancel', edit_content_page_content_page_version_path(@content_page_version.content_page, @content_page_version), :data => {:confirm => "Are you sure you want to undo your changes ?", :class => "govuk-link"}%>
             </div>
           <% end %>
         </fieldset>

--- a/app/views/content_page_versions/_form.html.erb
+++ b/app/views/content_page_versions/_form.html.erb
@@ -26,7 +26,7 @@
           <% if action_name === "edit" || action_name === "new" || action_name === "update" %>
             <div class="fixed-footer">
               <%= form.govuk_submit "Save as draft" %>
-              <%= link_to 'Cancel', versions_content_page_path(@content_page_version.content_page), data: { confirm: "Any changes will be lost, are you sure ?"}, class: "govuk-link" %>
+              <%= link_to 'Cancel', versions_content_page_path(@content_page_version.content_page), data: { confirm: "Any changes will be lost, are you sure ?" }, class: "govuk-link" %>
             </div>
           <% end %>
         </fieldset>

--- a/app/views/content_page_versions/_form.html.erb
+++ b/app/views/content_page_versions/_form.html.erb
@@ -26,7 +26,7 @@
           <% if action_name === "edit" || action_name === "new" || action_name === "update" %>
             <div class="fixed-footer">
               <%= form.govuk_submit "Save as draft" %>
-              <%= link_to 'Cancel', edit_content_page_content_page_version_path(@content_page_version.content_page, @content_page_version), data: { confirm: 'Are you sure you want to undo your changes ?' }, class: "govuk-link" %>
+              <%= link_to 'Cancel', versions_content_page_path(@content_page_version.content_page), data: { confirm: "Any changes will be lost, are you sure ?"}, class: "govuk-link" %>
             </div>
           <% end %>
         </fieldset>

--- a/app/views/content_page_versions/_form.html.erb
+++ b/app/views/content_page_versions/_form.html.erb
@@ -26,7 +26,7 @@
           <% if action_name === "edit" || action_name === "new" || action_name === "update" %>
             <div class="fixed-footer">
               <%= form.govuk_submit "Save as draft" %>
-              <%= link_to 'Cancel', edit_content_page_content_page_version_path(@content_page_version.content_page, @content_page_version), :data => {:confirm => "Are you sure you want to undo your changes ?", :class => "govuk-link"}%>
+              <%= link_to 'Cancel', edit_content_page_content_page_version_path(@content_page_version.content_page, @content_page_version), data: { confirm: 'Are you sure you want to undo your changes ?' }, class: "govuk-link" %>
             </div>
           <% end %>
         </fieldset>

--- a/app/views/content_pages/_form.html.erb
+++ b/app/views/content_pages/_form.html.erb
@@ -28,7 +28,7 @@
         <div class="fixed-footer">
           <%= form.govuk_submit "Save" %>
           <% if action_name === "edit" || action_name === "update" %>
-            <%= link_to 'Cancel', edit_content_page_path(content_page), data: { confirm: 'Are you sure you want to undo your changes ?' }, class: "govuk-link" %>
+            <%= link_to 'Cancel', versions_content_page_path(content_page), data: { confirm: "Any changes will be lost, are you sure ?" }, class: "govuk-link" %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/content_pages/_form.html.erb
+++ b/app/views/content_pages/_form.html.erb
@@ -28,8 +28,7 @@
         <div class="fixed-footer">
           <%= form.govuk_submit "Save" %>
           <% if action_name === "edit" || action_name === "update" %>
-            <%= link_to 'Cancel', edit_content_page_path(content_page), :data => {:confirm => "Are you sure you want to undo your changes ?", :class => "govuk-link"}%> |
-            <%= link_to 'Back', versions_content_page_path(content_page), :data => {:confirm => "Any changes will be lost, are you sure ?", :class => "govuk-link"}%>
+            <%= link_to 'Cancel', edit_content_page_path(content_page), :data => {:confirm => "Are you sure you want to undo your changes ?", :class => "govuk-link"}%>
           <% end %>
         </div>
       <% end %>

--- a/app/views/content_pages/_form.html.erb
+++ b/app/views/content_pages/_form.html.erb
@@ -28,7 +28,7 @@
         <div class="fixed-footer">
           <%= form.govuk_submit "Save" %>
           <% if action_name === "edit" || action_name === "update" %>
-            <%= link_to 'Cancel', edit_content_page_path(content_page), :data => {:confirm => "Are you sure you want to undo your changes ?", :class => "govuk-link"}%>
+            <%= link_to 'Cancel', edit_content_page_path(content_page), data: { confirm: 'Are you sure you want to undo your changes ?' }, class: "govuk-link" %>
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
## Ticket and context

Ticket: [HFEYP-597](https://dfedigital.atlassian.net/browse/HFEYP-597)
Removed the back button from the edit published and draft pages. Cancel button remains.
## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true

## Product review

### How can someone see it in review app?
1. Click the link to review app and go to `/cms/pages` [or click this link](https://eyfs-cms-review-pr-530.london.cloudapps.digital/cms/pages)
2. Choose a page and click `versions`
3. Click `edit` next to a live page
4. Add some content
5. Click `cancel` at the bottom. Verify that there is a dialog box to confirm the cancellation. Verify that the edits are removed and the page reloads.