### PR TITLE
HFEYP-610 Enable User feedback

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -112,7 +112,7 @@ jobs:
           terraform apply -input=false -auto-approve -var-file ../workspace-variables/review.tfvars -var='secret_paas_app_env_values={"RAILS_MASTER_KEY":"${{secrets.RAILS_MASTER_KEY_DEV}}", "AWS_ACCESS_KEY_ID": "${{secrets.AWS_ACCESS_KEY_ID_SANDBOX}}", "AWS_SECRET_ACCESS_KEY": "${{secrets.AWS_SECRET_ACCESS_KEY_SANDBOX}}", "AWS_REGION": "${{secrets.AWS_REGION_SANDBOX}}", "AWS_BUCKET": "${{secrets.AWS_BUCKET_SANDBOX}}", "BASIC_AUTH_USER": "${{secrets.BASIC_AUTH_USER}}", "BASIC_AUTH_PASSWORD": "${{secrets.BASIC_AUTH_PASSWORD}}", "GOOGLE_ANALYTICS_CONTAINER_ID": "${{ secrets.GA_CONTAINER_ID_DEV }}", "GOOGLE_ANALYTICS_TRACKING_ID": "${{ secrets.GA_TRACKING_ID_DEV }}"}' -var='environment=${{env.ENVIRONMENT}}'
 
       - name: comment on PR
-        uses: unsplash/comment-on-pr@v1.3.0
+        uses: unsplash/comment-on-pr@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,0 +1,26 @@
+class FeedbacksController < ApplicationController
+  # rubocop:disable Rails/SaveBang
+  # POST /feedbacks
+  def create
+    feedback = Feedback.create(feedback_params)
+    cookies[:feedback_page_useful] = cookie(feedback)
+    uri = redirect_uri
+    uri.fragment = "feedback"
+    redirect_to uri.to_s
+  end
+# rubocop:enable Rails/SaveBang
+
+private
+
+  def redirect_uri
+    URI(request.referer.presence || root_path)
+  end
+
+  def cookie(feedback)
+    feedback.valid? ? { value: feedback.page_useful, expires: 5.seconds.from_now } : nil
+  end
+
+  def feedback_params
+    params.require(:feedback).permit(:page_useful).merge(page_url: request.referer)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,22 +10,4 @@ module ApplicationHelper
       end
     end
   end
-
-  def link_to_feedback(args = {})
-    link_to(
-      "Give Feedback",
-      Rails.configuration.x.feedback.remote_url,
-      {
-        class: "govuk-button",
-        data: {
-          track_category: "Onsite Feedback",
-          track_action: "GOV-UK Open Form"
-        },
-        aria: {
-          controls: "something-is-wrong",
-          expanded: "false"
-        }
-      }.merge(args)
-    )
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,22 @@ module ApplicationHelper
       end
     end
   end
+
+  def link_to_feedback(args = {})
+    link_to(
+      "Give Feedback",
+      Rails.configuration.x.feedback.remote_url,
+      {
+        class: "govuk-button",
+        data: {
+          track_category: "Onsite Feedback",
+          track_action: "GOV-UK Open Form"
+        },
+        aria: {
+          controls: "something-is-wrong",
+          expanded: "false"
+        }
+      }.merge(args)
+    )
+  end
 end

--- a/app/helpers/feedbacks_helper.rb
+++ b/app/helpers/feedbacks_helper.rb
@@ -1,0 +1,19 @@
+module FeedbacksHelper
+  def link_to_feedback(args = {})
+    link_to(
+      "Give Feedback",
+      Rails.configuration.x.feedback.remote_url,
+      {
+        class: "govuk-button",
+        data: {
+          track_category: "Onsite Feedback",
+          track_action: "GOV-UK Open Form",
+        },
+        aria: {
+          controls: "something-is-wrong",
+          expanded: "false",
+        },
+      }.merge(args),
+    )
+  end
+end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,0 +1,4 @@
+class Feedback < ApplicationRecord
+  validates :page_useful, inclusion: { in: %w[yes no] }
+  validates :page_url, presence: true
+end

--- a/app/views/layouts/_feedback.html.erb
+++ b/app/views/layouts/_feedback.html.erb
@@ -1,8 +1,18 @@
 <!--Feedback Section-->
-<div class="govuk-width-container govuk-!-padding-top-4">
+<div id="feedback" class="govuk-width-container govuk-!-padding-top-4" role="dialog" aria-label="feedback">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full govuk-!-padding-left-9 govuk-!-padding-right-9">
-      <%= render "layouts/feedback_default" %>
+      <%
+        partial = case cookies[:feedback_page_useful]
+        when "yes"
+          "positive"
+        when "no"
+          "negative"
+        else
+          "default"
+        end
+      %>
+      <%= render "layouts/feedback_#{partial}" %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/_feedback.html.erb
+++ b/app/views/layouts/_feedback.html.erb
@@ -2,33 +2,7 @@
 <div class="govuk-width-container govuk-!-padding-top-4">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full govuk-!-padding-left-9 govuk-!-padding-right-9">
-      <div class="gem-c-feedback" data-module="feedback">
-        <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
-          <div class="gem-c-feedback__prompt-questions js-prompt-questions">
-            <h2 class="govuk-heading-s gem-c-feedback__prompt-question">Is this page useful?</h2>
-            <!-- Maybe button exists only to try and capture clicks by bots -->
-
-            <ul class="gem-c-feedback__option-list">
-              <li class="gem-c-feedback__option-list-item">
-                <button class="govuk-button gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">
-                  Yes <span class="govuk-visually-hidden">this page is useful</span>
-                </button>
-              </li>
-              <li class="gem-c-feedback__option-list-item">
-                <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">
-                  No <span class="govuk-visually-hidden">this page is not useful</span>
-                </button>
-              </li>
-            </ul>
-          </div>
-
-          <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions">
-            <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" data-track-category="Onsite Feedback" data-track-action="GOV-UK Open Form" aria-controls="something-is-wrong" aria-expanded="false">
-              There is something wrong with this page
-            </button>
-          </div>
-        </div>
-      </div>
+      <%= render "layouts/feedback_default" %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/_feedback.html.erb
+++ b/app/views/layouts/_feedback.html.erb
@@ -1,9 +1,7 @@
 <!--Feedback Section-->
-<!-- feedback sections is currently designated as removed from the app but keeping in partial in case we need to re-add it later -->
-
 <div class="govuk-width-container govuk-!-padding-top-4">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-full govuk-!-padding-left-9 govuk-!-padding-right-9">
       <div class="gem-c-feedback" data-module="feedback">
         <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
           <div class="gem-c-feedback__prompt-questions js-prompt-questions">
@@ -30,9 +28,8 @@
             </button>
           </div>
         </div>
-
       </div>
     </div>
   </div>
 </div>
-<!--End of-->
+<!--End of Feedback Section-->

--- a/app/views/layouts/_feedback_default.html.erb
+++ b/app/views/layouts/_feedback_default.html.erb
@@ -2,24 +2,39 @@
   <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
     <div class="gem-c-feedback__prompt-questions js-prompt-questions">
       <h2 class="govuk-heading-s gem-c-feedback__prompt-question">Is this page useful?</h2>
-      <!-- Maybe button exists only to try and capture clicks by bots -->
 
       <ul class="gem-c-feedback__option-list">
         <li class="gem-c-feedback__option-list-item">
-          <button class="govuk-button gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">
+          <%= button_to(
+                feedbacks_path,
+                params: { 'feedback[page_useful]' => 'yes' },
+                class: "govuk-button gem-c-feedback__prompt-link",
+                data: {
+                  track_category: "yesNoFeedbackForm",
+                  track_action: "ffYesClick"
+                }
+              ) do  %>
             Yes <span class="govuk-visually-hidden">this page is useful</span>
-          </button>
+          <% end %>
         </li>
         <li class="gem-c-feedback__option-list-item">
-          <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">
+          <%= button_to(
+                feedbacks_path,
+                params: { 'feedback[page_useful]' => 'no' },
+                class: "govuk-button gem-c-feedback__prompt-link",
+                data: {
+                  track_category: "yesNoFeedbackForm",
+                  track_action: "ffNoClick"
+                }
+              ) do  %>
             No <span class="govuk-visually-hidden">this page is not useful</span>
-          </button>
+          <% end %>
         </li>
       </ul>
     </div>
 
     <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions">
-      <%= link_to_feedback class: "govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" %>
+      <%= link_to_feedback class: "govuk-button gem-c-feedback__prompt-link" %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/_feedback_default.html.erb
+++ b/app/views/layouts/_feedback_default.html.erb
@@ -1,0 +1,25 @@
+<div class="gem-c-feedback" data-module="feedback">
+  <div class="gem-c-feedback__prompt gem-c-feedback__js-show js-prompt" tabindex="-1">
+    <div class="gem-c-feedback__prompt-questions js-prompt-questions">
+      <h2 class="govuk-heading-s gem-c-feedback__prompt-question">Is this page useful?</h2>
+      <!-- Maybe button exists only to try and capture clicks by bots -->
+
+      <ul class="gem-c-feedback__option-list">
+        <li class="gem-c-feedback__option-list-item">
+          <button class="govuk-button gem-c-feedback__prompt-link js-page-is-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffYesClick">
+            Yes <span class="govuk-visually-hidden">this page is useful</span>
+          </button>
+        </li>
+        <li class="gem-c-feedback__option-list-item">
+          <button class="govuk-button gem-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="yesNoFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">
+            No <span class="govuk-visually-hidden">this page is not useful</span>
+          </button>
+        </li>
+      </ul>
+    </div>
+
+    <div class="gem-c-feedback__prompt-questions gem-c-feedback__prompt-questions--something-is-wrong js-prompt-questions">
+      <%= link_to_feedback class: "govuk-button gem-c-feedback__prompt-link js-toggle-form js-something-is-wrong" %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/_feedback_negative.html.erb
+++ b/app/views/layouts/_feedback_negative.html.erb
@@ -1,0 +1,19 @@
+<hr>
+<div class="govuk-grid-row  govuk-!-margin-top-4" tabindex="-1">
+  <div class="govuk-grid-column-three-quarters">
+    <h2 class="govuk-heading-m">
+      Help us improve Help for early years providers
+    </h2>
+    <p class="govuk-body">
+      We're sorry you didn't find this page useful. Please tell us why, so we can improve the site for everyone.
+      Our feedback form will take around 2 minutes to complete.
+    </p>
+
+    <%= link_to_feedback %>
+  </div>
+
+  <div class="govuk-grid-column-one-quarter">
+    <%= link_to "Close", root_path, class: "govuk-button govuk-button--secondary" %>
+  </div>
+</div>
+

--- a/app/views/layouts/_feedback_negative.html.erb
+++ b/app/views/layouts/_feedback_negative.html.erb
@@ -13,7 +13,12 @@
   </div>
 
   <div class="govuk-grid-column-one-quarter">
-    <%= link_to "Close", root_path, class: "govuk-button govuk-button--secondary" %>
+    <%= button_to(
+          "Close",
+          feedbacks_path,
+          params: { 'feedback[page_useful]' => 'reset' },
+          class: "govuk-button govuk-button--secondary"
+        ) %>
   </div>
 </div>
 

--- a/app/views/layouts/_feedback_positive.html.erb
+++ b/app/views/layouts/_feedback_positive.html.erb
@@ -1,0 +1,5 @@
+<div class="gem-c-feedback" data-module="feedback">
+  <div class="gem-c-feedback__prompt govuk-!-padding-5">
+     Thank you for your feedback
+  </div>
+</div>

--- a/app/views/layouts/_footer_content.html.erb
+++ b/app/views/layouts/_footer_content.html.erb
@@ -1,48 +1,44 @@
-<div class="govuk-width-container ">
-    
+<footer class="govuk-footer " role="contentinfo">
+  <div class="govuk-width-container ">
     <div class="govuk-footer__meta">
     <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-        
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        
-            <ul class="govuk-footer__inline-list">
-            
-                <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/accessibility-statement">
-                    Accessibility
-                </a>
-                </li>
-            
-                <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/settings/cookie-policy">
-                    Cookies
-                </a>
-                </li>
-            
-                <li class="govuk-footer__inline-list-item">
-                  <%= link_to "Contact us", contact_us_path, class: "govuk-footer__link" %>
-                </li>
-            
-                <li class="govuk-footer__inline-list-item">
-                <a class="govuk-footer__link" href="/disclaimer">
-                    Disclaimer
-                </a>
-                </li>
-            
-            </ul>
-        
-        
-        
-        <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
-        <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
-        </svg>
-        <span class="govuk-footer__licence-description">
-        All content is available under the
-        <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-        </span>
+      <h2 class="govuk-visually-hidden">Support links</h2>
+
+      <ul class="govuk-footer__inline-list">
+        <li class="govuk-footer__inline-list-item">
+        <a class="govuk-footer__link" href="/accessibility-statement">
+            Accessibility
+        </a>
+        </li>
+
+        <li class="govuk-footer__inline-list-item">
+        <a class="govuk-footer__link" href="/settings/cookie-policy">
+            Cookies
+        </a>
+        </li>
+
+        <li class="govuk-footer__inline-list-item">
+          <%= link_to "Contact us", contact_us_path, class: "govuk-footer__link" %>
+        </li>
+
+        <li class="govuk-footer__inline-list-item">
+        <a class="govuk-footer__link" href="/disclaimer">
+            Disclaimer
+        </a>
+        </li>
+      </ul>
+
+      <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+      <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
+      </svg>
+      <span class="govuk-footer__licence-description">
+      All content is available under the
+      <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+      </span>
     </div>
     <div class="govuk-footer__meta-item">
         <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
     </div>
     </div>
-</div>
+  </div>
+</footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,152 +1,149 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
-<head>
-  <meta name="Cache-Control" content="max-age=3500, public">
-  <title><%= @page.title %> - Help for early years providers - GOV.UK</title>
-  <%= render 'layouts/analytics_header' if cookies[:track_analytics] == 'Yes' %>
-  <%= csrf_meta_tags %>
-  <%= csp_meta_tag %>
-  <%= canonical_tag %>
-  <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
-  <%= tag :meta, property: 'og:image', content: asset_pack_path('media/images/govuk-opengraph-image.png') %>
-  <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
-  <%= tag(:meta, name: :description, content: @page.description) if @page.description.present? %>
-  <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
-  <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
-  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
-</head>
+  <head>
+    <meta name="Cache-Control" content="max-age=3500, public">
+    <title><%= @page.title %> - Help for early years providers - GOV.UK</title>
+    <%= render 'layouts/analytics_header' if cookies[:track_analytics] == 'Yes' %>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= canonical_tag %>
+    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
+    <%= tag :meta, property: 'og:image', content: asset_pack_path('media/images/govuk-opengraph-image.png') %>
+    <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
+    <%= tag(:meta, name: :description, content: @page.description) if @page.description.present? %>
+    <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+    <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
+  </head>
 
-<body class="govuk-template__body ">
-  <script>
-    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-  </script>
-  <%= render 'layouts/analytics_body' if cookies[:track_analytics] == 'Yes' %>
+  <body class="govuk-template__body ">
+    <script>
+      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+    </script>
+    <%= render 'layouts/analytics_body' if cookies[:track_analytics] == 'Yes' %>
 
-  <% if !cookies[:track_analytics] %>
-  <%= render 'layouts/cookies_notice'  %>
-  <% end %>
+    <% if !cookies[:track_analytics] %>
+    <%= render 'layouts/cookies_notice'  %>
+    <% end %>
 
-  <header class="govuk-header app-header" role="banner" data-module="govuk-header">
-  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-  <div class="govuk-header__container govuk-width-container">
-    <div class="govuk-header__logo govuk-!-padding-right-0">
-      <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <span class="govuk-header__logotype">
-          <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
-            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-            <image src="<%= asset_pack_path('media/images/govuk-logotype-crown.png') %>" xlink:href=""  class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
-          </svg>
-          <span class="govuk-header__logotype-text">
-            GOV.UK
-          </span>
-        </span>
-      </a>
-      <% if @page.navigation %>
-        <div class="app-header-mobile-nav-toggler-wrapper">
-          <button aria-controls="mobile-menu-nav" id="app-mobile-nav-toggler" class="govuk-js-header-toggle govuk-button eyfs-menu-button--border app-header-mobile-nav-toggler js-app-mobile-nav-toggler" aria-expanded="false">
-            Menu
-          </button>
-        </div>
-      <% end %>
-    </div>
-    <div class="govuk-header__content">
-      <a href="/" class="govuk-header__link govuk-header__link--service-name">
-        Help for early years providers
-      </a>
-    </div>
-  </div>
-  </header>
-
-  <%= render 'layouts/mobile_menu' %>
-
-  <%= render 'layouts/phase_banner' %>
-
-  <% if @page.breadcrumbs %>
-    <nav class="govuk-width-container" role="navigation" aria-label="Breadcrumbs">
-      <%= render 'layouts/breadcrumbs' %>
-    </nav>
-  <% end %>
-
-  <div class="govuk-width-container">
-    <main class="govuk-main-wrapper" role="main">
-      <div class="govuk-grid-row">
-        <% if @page.navigation %>
-          <div class="govuk-grid-column-one-third desktop-menu">
-            <%= render 'layouts/desktop_menu' %>
-          </div>
-        <% end %>
-
-        <div class="govuk-grid-column-two-thirds">
-          <div id="main-content" class="app-content gem-c-govspeak">
-            <%= render 'layouts/notice' %>
-            <%= yield %>
-            <% if @page.navigation %>
-              <nav class="gem-c-pagination" role="navigation" aria-label="Pagination">
-                <ul class="gem-c-pagination__list">
-                  <% if @page.previous_page %>
-                    <li class="gem-c-pagination__item gem-c-pagination__item--previous">
-                      <a href="<%= @page.previous_page.full_path %>" class="gem-c-pagination__link">
-                                    <span class="gem-c-pagination__link-title">
-                                        <svg class="gem-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                                        <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-                                        </svg>
-                                        <span class="gem-c-pagination__link-text">
-                                        Previous page
-                                        </span>
-                                    </span>
-                        <span class="gem-c-pagination__link-divider visually-hidden">:</span>
-                        <span class="gem-c-pagination__link-label"><%= @page.previous_page.title %></span>
-                      </a>
-                    </li>
-                  <% end %>
-                  <% if @page.next_page %>
-                    <li class="gem-c-pagination__item gem-c-pagination__item--next">
-                      <a href="<%= @page.next_page.full_path %>" class="gem-c-pagination__link">
-                                    <span class="gem-c-pagination__link-title">
-                                        <svg class="gem-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                                        <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-                                        </svg>
-                                        <span class="gem-c-pagination__link-text">
-                                        Next page
-                                        </span>
-                                    </span>
-                        <span class="gem-c-pagination__link-divider visually-hidden">:</span>
-                        <span class="gem-c-pagination__link-label"><%= @page.next_page.title %></span>
-                      </a>
-                    </li>
-                  <% end %>
-                </ul>
-              </nav>
-            <% end %>
-          </div>
-
-          <% if @page.helpful_tools %>
-            <div class="eyfs-helpful-tools">
-              <div class="app-back-to-top govuk-!-margin-bottom-7" data-module="app-back-to-top">
-                <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
-                  <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
-                    <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
-                  </svg>Back to top
-                </a>
-              </div>
-              <div class="gem-c-print-link govuk-!-margin-top-3 govuk-!-margin-bottom-6">
-                <button class="govuk-link gem-c-print-link__button" onclick="window.print()" data-module="print-link" >Print this page</button>
-              </div>
+    <header class="govuk-header app-header" role="banner" data-module="govuk-header">
+      <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+      <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo govuk-!-padding-right-0">
+          <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                <image src="<%= asset_pack_path('media/images/govuk-logotype-crown.png') %>" xlink:href=""  class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+              </svg>
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+          </a>
+          <% if @page.navigation %>
+            <div class="app-header-mobile-nav-toggler-wrapper">
+              <button aria-controls="mobile-menu-nav" id="app-mobile-nav-toggler" class="govuk-js-header-toggle govuk-button eyfs-menu-button--border app-header-mobile-nav-toggler js-app-mobile-nav-toggler" aria-expanded="false">
+                Menu
+              </button>
             </div>
           <% end %>
         </div>
+        <div class="govuk-header__content">
+          <a href="/" class="govuk-header__link govuk-header__link--service-name">
+            Help for early years providers
+          </a>
+        </div>
       </div>
-    </main>
-  </div>
+    </header>
 
-  <footer class="govuk-footer " role="contentinfo">
+    <%= render 'layouts/mobile_menu' %>
+
+    <%= render 'layouts/phase_banner' %>
+
+    <% if @page.breadcrumbs %>
+      <nav class="govuk-width-container" role="navigation" aria-label="Breadcrumbs">
+        <%= render 'layouts/breadcrumbs' %>
+      </nav>
+    <% end %>
+
+    <div class="govuk-width-container">
+      <main class="govuk-main-wrapper" role="main">
+        <div class="govuk-grid-row">
+          <% if @page.navigation %>
+            <div class="govuk-grid-column-one-third desktop-menu">
+              <%= render 'layouts/desktop_menu' %>
+            </div>
+          <% end %>
+
+          <div class="govuk-grid-column-two-thirds">
+            <div id="main-content" class="app-content gem-c-govspeak">
+              <%= render 'layouts/notice' %>
+              <%= yield %>
+              <% if @page.navigation %>
+                <nav class="gem-c-pagination" role="navigation" aria-label="Pagination">
+                  <ul class="gem-c-pagination__list">
+                    <% if @page.previous_page %>
+                      <li class="gem-c-pagination__item gem-c-pagination__item--previous">
+                        <a href="<%= @page.previous_page.full_path %>" class="gem-c-pagination__link">
+                          <span class="gem-c-pagination__link-title">
+                              <svg class="gem-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                              <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+                              </svg>
+                              <span class="gem-c-pagination__link-text">
+                              Previous page
+                              </span>
+                          </span>
+                          <span class="gem-c-pagination__link-divider visually-hidden">:</span>
+                          <span class="gem-c-pagination__link-label"><%= @page.previous_page.title %></span>
+                        </a>
+                      </li>
+                    <% end %>
+                    <% if @page.next_page %>
+                      <li class="gem-c-pagination__item gem-c-pagination__item--next">
+                        <a href="<%= @page.next_page.full_path %>" class="gem-c-pagination__link">
+                          <span class="gem-c-pagination__link-title">
+                              <svg class="gem-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                              <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+                              </svg>
+                              <span class="gem-c-pagination__link-text">
+                              Next page
+                              </span>
+                          </span>
+                          <span class="gem-c-pagination__link-divider visually-hidden">:</span>
+                          <span class="gem-c-pagination__link-label"><%= @page.next_page.title %></span>
+                        </a>
+                      </li>
+                    <% end %>
+                  </ul>
+                </nav>
+              <% end %>
+            </div>
+
+            <% if @page.helpful_tools %>
+              <div class="eyfs-helpful-tools">
+                <div class="app-back-to-top govuk-!-margin-bottom-7" data-module="app-back-to-top">
+                  <a class="govuk-link govuk-link--no-visited-state app-back-to-top__link" href="#top">
+                    <svg role="presentation" focusable="false" class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+                      <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+                    </svg>Back to top
+                  </a>
+                </div>
+                <div class="gem-c-print-link govuk-!-margin-top-3 govuk-!-margin-bottom-6">
+                  <button class="govuk-link gem-c-print-link__button" onclick="window.print()" data-module="print-link" >Print this page</button>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </main>
+    </div>
+    <%= render 'layouts/feedback' %>
     <%= render 'layouts/footer_content' %>
-  </footer>
-
-</body>
+  </body>
 </html>

--- a/app/views/layouts/article_pages.html.erb
+++ b/app/views/layouts/article_pages.html.erb
@@ -1,75 +1,74 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
-<head>
-  <meta charset="utf-8">
-  <title>Help for early years providers - Department for Education</title>
-  <%= csrf_meta_tags %>
-  <%= csp_meta_tag %>
-  <%= canonical_tag %>
-  <%= render 'layouts/analytics_header' if cookies[:track_analytics] == 'Yes' %>
-  <%= render 'layouts/hotjar' if cookies[:track_analytics] == 'Yes' %>
-  <meta Cache-Control="max-age=3500, public">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <meta name="theme-color" content="#0b0c0c">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <%= tag(:meta, name: :description, content: @article.description) if @article.description.present? %>
+  <head>
+    <meta charset="utf-8">
+    <title>Help for early years providers - Department for Education</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= canonical_tag %>
+    <%= render 'layouts/analytics_header' if cookies[:track_analytics] == 'Yes' %>
+    <%= render 'layouts/hotjar' if cookies[:track_analytics] == 'Yes' %>
+    <meta Cache-Control="max-age=3500, public">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <%= tag(:meta, name: :description, content: @article.description) if @article.description.present? %>
 
-  <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+    <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
 
-  <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
-  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
+    <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
 
-  <meta property="og:image" content="/govuk/assets/images/govuk-opengraph-image.png">
-</head>
-<body class="govuk-template__body">
+    <meta property="og:image" content="/govuk/assets/images/govuk-opengraph-image.png">
+  </head>
+  <body class="govuk-template__body">
 
-<header class="govuk-header app-header" role="banner" data-module="govuk-header">
-<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-  <div class="govuk-header__container govuk-width-container">
-    <div class="govuk-header__logo govuk-!-padding-right-0">
-      <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <span class="govuk-header__logotype">
-          <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
-            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-            <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
-          </svg>
-          <span class="govuk-header__logotype-text">
-            GOV.UK
-          </span>
-        </span>
-      </a>
-    </div>
-    <div class="govuk-header__content">
-      <a href="/" class="govuk-header__link govuk-header__link--service-name">
-        Help for early years providers
-      </a>
-    </div>
-  </div>
-</header>
-
-<aside title="Breadcrumbs">
-  <div class="govuk-width-container govuk-!-margin-top-4">
-    <%= render 'layouts/articles_breadcrumbs' %>
-  </div>
-</aside>
-
-<div class="govuk-width-container">
-  <main class="eyfs-wrapper" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        <%= yield %>
+    <header class="govuk-header app-header" role="banner" data-module="govuk-header">
+      <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+      <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo govuk-!-padding-right-0">
+          <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+              </svg>
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+          </a>
+        </div>
+        <div class="govuk-header__content">
+          <a href="/" class="govuk-header__link govuk-header__link--service-name">
+            Help for early years providers
+          </a>
+        </div>
       </div>
-    </div>
-  </main>
-</div>
+    </header>
 
-<footer class="govuk-footer" role="contentinfo">
-  <%= render 'layouts/footer_content' %>
-</footer>
-</body>
+    <aside title="Breadcrumbs">
+      <div class="govuk-width-container govuk-!-margin-top-4">
+        <%= render 'layouts/articles_breadcrumbs' %>
+      </div>
+    </aside>
+
+    <div class="govuk-width-container">
+      <main class="eyfs-wrapper" role="main">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            <%= yield %>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <%= render 'layouts/feedback' %>
+    <%= render 'layouts/footer_content' %>
+  </body>
 </html>

--- a/app/views/layouts/articles_landing_page_layout.html.erb
+++ b/app/views/layouts/articles_landing_page_layout.html.erb
@@ -1,68 +1,67 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
-<head>
-  <meta charset="utf-8">
-  <title>Help for early years providers - Department for Education</title>
-  <%= csrf_meta_tags %>
-  <%= csp_meta_tag %>
-  <%= canonical_tag %>
-  <%= render 'layouts/analytics_header' if cookies[:track_analytics] == 'Yes' %>
-  <%= render 'layouts/hotjar' if cookies[:track_analytics] == 'Yes' %>
-  <meta Cache-Control="max-age=3500, public">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <meta name="theme-color" content="#0b0c0c">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <head>
+    <meta charset="utf-8">
+    <title>Help for early years providers - Department for Education</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= canonical_tag %>
+    <%= render 'layouts/analytics_header' if cookies[:track_analytics] == 'Yes' %>
+    <%= render 'layouts/hotjar' if cookies[:track_analytics] == 'Yes' %>
+    <meta Cache-Control="max-age=3500, public">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+    <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
 
-  <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
-  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
+    <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
 
-  <meta property="og:image" content="/govuk/assets/images/govuk-opengraph-image.png">
-</head>
-<body class="govuk-template__body">
+    <meta property="og:image" content="/govuk/assets/images/govuk-opengraph-image.png">
+  </head>
+  <body class="govuk-template__body">
 
-<header class="govuk-header app-header" role="banner" data-module="govuk-header">
-<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-  <div class="govuk-header__container govuk-width-container">
-    <div class="govuk-header__logo govuk-!-padding-right-0">
-      <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <span class="govuk-header__logotype">
-          <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
-            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-            <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
-          </svg>
-          <span class="govuk-header__logotype-text">
-            GOV.UK
-          </span>
-        </span>
-      </a>
-    </div>
-    <div class="govuk-header__content">
-      <a href="/" class="govuk-header__link govuk-header__link--service-name">
-        Help for early years providers
-      </a>
-    </div>
-  </div>
-</header>
+    <header class="govuk-header app-header" role="banner" data-module="govuk-header">
+      <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+      <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo govuk-!-padding-right-0">
+          <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+              </svg>
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+          </a>
+        </div>
+        <div class="govuk-header__content">
+          <a href="/" class="govuk-header__link govuk-header__link--service-name">
+            Help for early years providers
+          </a>
+        </div>
+      </div>
+    </header>
 
-<aside title="Breadcrumbs">
-  <div class="govuk-width-container govuk-!-margin-top-4">
-    <%= render 'layouts/articles_breadcrumbs' %>
-  </div>
-</aside>
+    <aside title="Breadcrumbs">
+      <div class="govuk-width-container govuk-!-margin-top-4">
+        <%= render 'layouts/articles_breadcrumbs' %>
+      </div>
+    </aside>
 
-<main class="eyfs-wrapper" role="main">
-  <%= yield %>
-</main>
+    <main class="eyfs-wrapper" role="main">
+      <%= yield %>
+    </main>
 
-<footer class="govuk-footer" role="contentinfo">
-  <%= render 'layouts/footer_content' %>
-</footer>
-</body>
+    <%= render 'layouts/feedback' %>
+    <%= render 'layouts/footer_content' %>
+  </body>
 </html>

--- a/app/views/layouts/cms.html.erb
+++ b/app/views/layouts/cms.html.erb
@@ -68,8 +68,6 @@
       </main>
     </div>
 
-    <footer class="govuk-footer " role="contentinfo">
-      <%= render 'layouts/footer_content' %>
-    </footer>
+    <%= render 'layouts/footer_content' %>
   </body>
 </html>

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -1,65 +1,64 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
-<head>
-  <title>Help for early years providers</title>
-  <%= csrf_meta_tags %>
-  <%= csp_meta_tag %>
-  <%= canonical_tag %>
-  <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
-  <%= tag :meta, property: 'og:image', content: asset_pack_path('media/images/govuk-opengraph-image.png') %>
-  <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
-  <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
-  <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
-  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
+  <head>
+    <title>Help for early years providers</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= canonical_tag %>
+    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
+    <%= tag :meta, property: 'og:image', content: asset_pack_path('media/images/govuk-opengraph-image.png') %>
+    <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
+    <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+    <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
 
-</head>
+  </head>
 
-<body class="govuk-template__body ">
-<script>
-  document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-</script>
+  <body class="govuk-template__body ">
+  <script>
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+  </script>
 
 
-  <header class="govuk-header app-header" role="banner" data-module="govuk-header">
-  <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-  <div class="govuk-header__container govuk-width-container">
-    <div class="govuk-header__logo govuk-!-padding-right-0">
-      <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <span class="govuk-header__logotype">
-          <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
-            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-            <image src="<%= asset_pack_path('media/images/govuk-logotype-crown.png') %>" xlink:href=""  class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
-          </svg>
-          <span class="govuk-header__logotype-text">
-            GOV.UK
+    <header class="govuk-header app-header" role="banner" data-module="govuk-header">
+    <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+    <div class="govuk-header__container govuk-width-container">
+      <div class="govuk-header__logo govuk-!-padding-right-0">
+        <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
+          <span class="govuk-header__logotype">
+            <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+              <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+              <image src="<%= asset_pack_path('media/images/govuk-logotype-crown.png') %>" xlink:href=""  class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+            </svg>
+            <span class="govuk-header__logotype-text">
+              GOV.UK
+            </span>
           </span>
-        </span>
-      </a>
+        </a>
+      </div>
+      <div class="govuk-header__content">
+        <a href="/" class="govuk-header__link govuk-header__link--service-name">
+          Help for early years providers
+        </a>
+      </div>
     </div>
-    <div class="govuk-header__content">
-      <a href="/" class="govuk-header__link govuk-header__link--service-name">
-        Help for early years providers
-      </a>
-    </div>
+    </header>
+
+  <%= render 'layouts/phase_banner' %>
+
+  <div class="govuk-width-container">
+    <main class="govuk-main-wrapper" role="main" id="main-content">
+      <%= render 'layouts/notice' %>
+      <%= yield %>
+    </main>
   </div>
-  </header>
 
-<%= render 'layouts/phase_banner' %>
-
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper" role="main" id="main-content">
-    <%= render 'layouts/notice' %>
-    <%= yield %>
-  </main>
-</div>
-
-<footer class="govuk-footer" role="contentinfo">
+  <%= render 'layouts/feedback' %>
   <%= render 'layouts/footer_content' %>
-</footer>
-</body>
+  </body>
 </html>

--- a/app/views/layouts/landing_page_layout.html.erb
+++ b/app/views/layouts/landing_page_layout.html.erb
@@ -1,85 +1,83 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
-<head>
-  <meta charset="utf-8">
-  <title>Help for early years providers - Department for Education</title>
-  <%= csrf_meta_tags %>
-  <%= csp_meta_tag %>
-  <%= canonical_tag %>
-  <%= render 'layouts/analytics_header' if cookies[:track_analytics] == 'Yes' %>
-  <%= render 'layouts/hotjar' if cookies[:track_analytics] == 'Yes' %>
-  <meta Cache-Control="max-age=3500, public">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <meta name="theme-color" content="#0b0c0c">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <head>
+    <meta charset="utf-8">
+    <title>Help for early years providers - Department for Education</title>
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= canonical_tag %>
+    <%= render 'layouts/analytics_header' if cookies[:track_analytics] == 'Yes' %>
+    <%= render 'layouts/hotjar' if cookies[:track_analytics] == 'Yes' %>
+    <meta Cache-Control="max-age=3500, public">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-  <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
-  <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
+    <%= favicon_link_tag asset_pack_path('media/images/favicon.ico') %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-mask-icon.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon.png'), rel: 'apple-touch-icon', type: 'image/png' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-152x152.png'), rel: 'apple-touch-icon', type: 'image/png', size: '152x152' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-167x167.png'), rel: 'apple-touch-icon', type: 'image/png', size: '167x167' %>
+    <%= favicon_link_tag asset_pack_path('media/images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
 
-  <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
-  <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
+    <%= stylesheet_pack_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
+    <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
 
-  <meta property="og:image" content="/govuk/assets/images/govuk-opengraph-image.png">
-</head>
-<body class="govuk-template__body">
+    <meta property="og:image" content="/govuk/assets/images/govuk-opengraph-image.png">
+  </head>
+  <body class="govuk-template__body">
 
-<script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
-<%= render 'layouts/analytics_body' if cookies[:track_analytics] == 'Yes' %>
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <%= render 'layouts/analytics_body' if cookies[:track_analytics] == 'Yes' %>
 
-<% if !cookies[:track_analytics] %>
-<%= render 'layouts/cookies_notice'  %>
-<% end %>
+    <% if !cookies[:track_analytics] %>
+    <%= render 'layouts/cookies_notice'  %>
+    <% end %>
 
-<header class="govuk-header app-header" role="banner" data-module="govuk-header">
-<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-  <div class="govuk-header__container govuk-width-container">
-    <div class="govuk-header__logo govuk-!-padding-right-0">
-      <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
-        <span class="govuk-header__logotype">
-          <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
-            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-            <image src="<%= asset_pack_path('media/images/govuk-logotype-crown.png') %>" xlink:href=""  class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
-          </svg>
-          <span class="govuk-header__logotype-text">
-            GOV.UK
-          </span>
-        </span>
-      </a>
-    </div>
-    <div class="govuk-header__content">
-      <a href="/" class="govuk-header__link govuk-header__link--service-name">
-        Help for early years providers
-      </a>
-    </div>
-  </div>
-</header>
+    <header class="govuk-header app-header" role="banner" data-module="govuk-header">
+      <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+      <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo govuk-!-padding-right-0">
+          <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
+            <span class="govuk-header__logotype">
+              <svg aria-hidden="true" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 132 97" height="30" width="36">
+                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+                <image src="<%= asset_pack_path('media/images/govuk-logotype-crown.png') %>" xlink:href=""  class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+              </svg>
+              <span class="govuk-header__logotype-text">
+                GOV.UK
+              </span>
+            </span>
+          </a>
+        </div>
+        <div class="govuk-header__content">
+          <a href="/" class="govuk-header__link govuk-header__link--service-name">
+            Help for early years providers
+          </a>
+        </div>
+      </div>
+    </header>
 
-<%= render 'layouts/phase_banner' %>
+    <%= render 'layouts/phase_banner' %>
 
-<aside title="Get alerts">
-  <div class="govuk-width-container govuk-!-margin-top-4">
-    <%= render 'layouts/notice' %>
+    <aside title="Get alerts">
+      <div class="govuk-width-container govuk-!-margin-top-4">
+        <%= render 'layouts/notice' %>
 
-    <div class="eyfs-signup-link--with-background-and-border">
-        <svg class="eyfs-signup-link__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-          <path d="M15.137 3.945c-.644-.374-1.042-1.07-1.041-1.82v-.003c.001-1.172-.938-2.122-2.096-2.122s-2.097.95-2.097 2.122v.003c.001.751-.396 1.446-1.041 1.82-4.667 2.712-1.985 11.715-6.862 13.306v1.749h20v-1.749c-4.877-1.591-2.195-10.594-6.863-13.306zm-3.137-2.945c.552 0 1 .449 1 1 0 .552-.448 1-1 1s-1-.448-1-1c0-.551.448-1 1-1zm3 20c0 1.598-1.392 3-2.971 3s-3.029-1.402-3.029-3h6z"/>
-        </svg>
-        <h1 class="govuk-heading-s eyfs-signup-link__title">Get alerts for new EYFS resources</h1>
-        <a class="govuk-link eyfs-signup-link__link" target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/e/1FAIpQLSdZbPz-447CADTErT9eD1IU4yKfsEhyJy1C8U1fyFAQuEtejw/viewform?usp=sf_link">Sign up to get emails when we add new early years foundation stage resources to this website</a>
-    </div>
-  </div>
-</aside>
+        <div class="eyfs-signup-link--with-background-and-border">
+            <svg class="eyfs-signup-link__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+              <path d="M15.137 3.945c-.644-.374-1.042-1.07-1.041-1.82v-.003c.001-1.172-.938-2.122-2.096-2.122s-2.097.95-2.097 2.122v.003c.001.751-.396 1.446-1.041 1.82-4.667 2.712-1.985 11.715-6.862 13.306v1.749h20v-1.749c-4.877-1.591-2.195-10.594-6.863-13.306zm-3.137-2.945c.552 0 1 .449 1 1 0 .552-.448 1-1 1s-1-.448-1-1c0-.551.448-1 1-1zm3 20c0 1.598-1.392 3-2.971 3s-3.029-1.402-3.029-3h6z"/>
+            </svg>
+            <h1 class="govuk-heading-s eyfs-signup-link__title">Get alerts for new EYFS resources</h1>
+            <a class="govuk-link eyfs-signup-link__link" target="_blank" rel="noopener noreferrer" href="https://docs.google.com/forms/d/e/1FAIpQLSdZbPz-447CADTErT9eD1IU4yKfsEhyJy1C8U1fyFAQuEtejw/viewform?usp=sf_link">Sign up to get emails when we add new early years foundation stage resources to this website</a>
+        </div>
+      </div>
+    </aside>
 
-<main class="eyfs-wrapper" role="main">
-  <%= yield %>
-</main>
-
-<footer class="govuk-footer" role="contentinfo">
-  <%= render 'layouts/footer_content' %>
-</footer>
-</body>
+    <main class="eyfs-wrapper" role="main">
+      <%= yield %>
+    </main>
+    <%= render 'layouts/feedback' %>
+    <%= render 'layouts/footer_content' %>
+  </body>
 </html>

--- a/app/webpacker/styles/layout-eyfs/landing-page.scss
+++ b/app/webpacker/styles/layout-eyfs/landing-page.scss
@@ -335,8 +335,13 @@
 
 //styles for feedback
 
-.js-enabled .gem-c-feedback__js-show, .js-enabled .gem-c-feedback__prompt-success, .js-enabled .gem-c-feedback__prompt-questions, .js-enabled .gem-c-feedback__error-summary {
-  display: block;
+.js-enabled {
+  .gem-c-feedback__js-show,
+  .gem-c-feedback__prompt-success,
+  .gem-c-feedback__prompt-questions,
+  .gem-c-feedback__error-summary {
+    display: inline-block;
+  }
 }
 
 .gem-c-feedback {
@@ -359,7 +364,7 @@
 .gem-c-feedback__prompt-questions {
   text-align: center;
   border-bottom: 1px solid #fff;
-  padding: 25px 25px 25px 25px;
+  padding: 15px 25px 0;
   box-sizing: border-box;
 }
 

--- a/app/webpacker/styles/layout-eyfs/landing-page.scss
+++ b/app/webpacker/styles/layout-eyfs/landing-page.scss
@@ -407,3 +407,9 @@
   border: 1px #fff solid;
   min-width: 100px;
 }
+
+@media only screen and (max-width: 350px) {
+  .gem-c-feedback__prompt-link {
+    min-width: 10px;
+  }
+}

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,7 @@ module GovukRailsBoilerplate
     config.space = ENV.fetch( 'DOMAIN', "eyfs-dev" ).split(".").first
 
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', 'content', '*.{rb,yml}').to_s]
+
+    config.x.feedback.remote_url = "https://docs.google.com/forms/d/e/1FAIpQLSeLpjkKhcwKUjBKRx29fUgzgslSAkE9pPzkcmp3Oer5T6JHDw/viewform"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,9 @@ Rails.application.routes.draw do
   end
 
   resources :articles, only: %i[index show]
+  resources :feedbacks, only: %i[create] do
+    post "reset", on: :collection
+  end
 
   get "/:section/:slug", to: "content#show"
   get "/:slug", to: "content#show"

--- a/db/migrate/20220105165412_create_feedbacks.rb
+++ b/db/migrate/20220105165412_create_feedbacks.rb
@@ -1,0 +1,10 @@
+class CreateFeedbacks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :feedbacks do |t|
+      t.string :page_useful
+      t.string :page_url
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_23_142331) do
+ActiveRecord::Schema.define(version: 2022_01_05_165412) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -129,6 +129,13 @@ ActiveRecord::Schema.define(version: 2021_11_23_142331) do
     t.string "description"
     t.index ["position", "parent_id"], name: "index_content_pages_on_position_and_parent_id", unique: true
     t.index ["title"], name: "index_content_pages_on_title", unique: true
+  end
+
+  create_table "feedbacks", force: :cascade do |t|
+    t.string "page_useful"
+    t.string "page_url"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.feature "Feedback", type: :feature do
+  scenario "Page with feedback options" do
+    visit "/"
+
+    expect(page).to have_text("Is this page useful?")
+    expect(page).to be_axe_clean
+  end
+
+  scenario "User gives positive feedback" do
+    visit "/"
+
+    within "#feedback" do
+      page.click_button("Yes")
+    end
+    expect(page).not_to have_text("Is this page useful?")
+    expect(page).to have_text("Thank you for your feedback")
+    expect(page).to be_axe_clean
+  end
+
+  scenario "User gives negative feedback and closes dialogue" do
+    visit "/"
+
+    within "#feedback" do
+      page.click_button("No")
+    end
+    expect(page).not_to have_text("Is this page useful?")
+    expect(page).to have_text("Help us improve Help for early years providers")
+    expect(page).to be_axe_clean
+
+    within "#feedback" do
+      page.click_button("Close")
+    end
+
+    expect(page).to have_text("Is this page useful?")
+  end
+end

--- a/spec/requests/feedbacks_spec.rb
+++ b/spec/requests/feedbacks_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe "/feedbacks", type: :request do
+  let(:valid_attributes) do
+    { page_useful: %w[yes no].sample }
+  end
+
+  let(:invalid_attributes) do
+    { page_useful: "foo" }
+  end
+  let(:redirect_url) { contact_us_url }
+
+  describe "POST /create" do
+    context "with valid parameters" do
+      subject { post feedbacks_url, params: { feedback: valid_attributes }, headers: { "HTTP_REFERER" => redirect_url } }
+
+      it "creates a new Feedback" do
+        expect { subject }.to change(Feedback, :count).by(1)
+      end
+
+      it "records user input" do
+        subject
+        expect(Feedback.last.page_useful).to eq(valid_attributes[:page_useful])
+      end
+
+      it "records page feedback applies to" do
+        subject
+        expect(Feedback.last.page_url).to eq(redirect_url)
+      end
+
+      it "redirects back to referring page with target feedback" do
+        subject
+        expect(response).to redirect_to("#{redirect_url}#feedback")
+      end
+
+      it "sets cookie to input" do
+        subject
+        expect(cookies[:feedback_page_useful]).to eq(valid_attributes[:page_useful])
+      end
+    end
+
+    context "with invalid parameters" do
+      subject { post feedbacks_url, params: { feedback: invalid_attributes }, headers: { "HTTP_REFERER" => redirect_url } }
+
+      it "does not create a new Feedback" do
+        expect { subject }.to change(Feedback, :count).by(0)
+      end
+
+      it "redirects back to referring page with target feedback" do
+        subject
+        expect(response).to redirect_to("#{redirect_url}#feedback")
+      end
+
+      it "clears cookie" do
+        subject
+        expect(cookies[:feedback_page_useful]).to be_blank
+      end
+    end
+
+    context "without referer" do
+      subject { post feedbacks_url, params: { feedback: valid_attributes } }
+
+      it "does not create a new Feedback" do
+        expect { subject }.to change(Feedback, :count).by(0)
+      end
+
+      it "redirects back to root with target feedback" do
+        subject
+        expect(response).to redirect_to("#{root_path}#feedback")
+      end
+
+      it "clears cookie" do
+        subject
+        expect(cookies[:feedback_page_useful]).to be_blank
+      end
+    end
+
+    context "with invalid parameter and cookie set" do
+      before { cookies[:feedback_page_userful] = "yes" }
+      subject { post feedbacks_url, params: { feedback: invalid_attributes }, headers: { "HTTP_REFERER" => redirect_url } }
+
+      it "does not create a new Feedback" do
+        expect { subject }.to change(Feedback, :count).by(0)
+      end
+
+      it "clears cookie" do
+        subject
+        expect(cookies[:feedback_page_useful]).to be_blank
+      end
+
+      it "redirects back to referring page with target feedback" do
+        subject
+        expect(response).to redirect_to("#{redirect_url}#feedback")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Ticket and context

Ticket: [HFEYP-610](https://dfedigital.atlassian.net/browse/HFEYP-610)

## Acceptance criteria
### Feedback panel

- Users can view the Feedback panel across all website page footer as per design from ife.akinbolaji 
- ‘Give feedback’ button should take user to the Google form[Help for Early Years Providers ]
- User click on ‘Yes’ button should display the message “Thank you for your feedback”
- User click on ‘No’ should expand the form with options to:
  - view the text as per wireframe
  - “Close” button to close the form and return to original state, and retain focus on the ‘No’ button as per screenshot
  - and “Give feedback” to take user to the Google form [Help for Early Years Providers ] in a new tab, and retain focus on the “Give feedback” button

## Tech review
There is a little tiding up of the spacing in layouts included.

### Code quality checks
- [ ] All commit messages are meaningful and true

### How can someone see it in review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. The feedback form should be visible at the bottom of the page. Test the functionality described above.
3. Navigate to another page and make sure the functionality works there too.