### PR TITLE
update page title, now responsive to article title and correctly ends…

### DIFF
--- a/app/views/layouts/article_pages.html.erb
+++ b/app/views/layouts/article_pages.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
 <head>
   <meta charset="utf-8">
-  <title>Help for early years providers - Department for Education</title>
+  <title><%= @article.title %> - Help for early years providers - GOV.UK</title>
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
   <%= canonical_tag %>


### PR DESCRIPTION
… with "GOV.UK"

## Ticket and context

Ticket: [HFEYP-631](https://dfedigital.atlassian.net/browse/HFEYP-631)
## Tech review

Updated page title of articles to now display "[Article title] - Help for early years providers - GOV.UK"

### Code quality checks
- [ ] All commit messages are meaningful and true

## Product review

### How can someone see it in review app?
1. Click the [link to article in review app](https://eyfs-cms-review-pr-537.london.cloudapps.digital/articles/test-article)
2. Verify that page title matches article title, followed by " - Help for early years providers - GOV.UK"
<img width="1852" alt="Screenshot 2022-01-07 at 15 17 09" src="https://user-images.githubusercontent.com/13471320/148564920-d04e604e-c353-4ded-8c4b-909ec137c88b.png">

