### PR TITLE
HFEYP-626 Adds alt text to article feature image with helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
     return unless page.featured_image.attached?
 
     tag.div(class: "page-img-container") do
-      image_tag(url_for(page.featured_image), class: "page-responsive-img", alt: page.featured_alt_text, title: page.title, width: "500px")
+      image_tag(url_for(page.featured_image), class: "page-responsive-img", alt: page.featured_alt_text, title: page.featured_alt_text, width: "500px")
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,10 +12,10 @@ module ApplicationHelper
   end
 
   def feature_image(page:)
-    if page.featured_image.attached?
-      tag.div(class: "page-img-container") do
-        image_tag(url_for(page.featured_image), class: "page-responsive-img", alt: page.featured_alt_text, title: page.title, width: "500px")
-      end
+    return unless page.featured_image.attached?
+
+    tag.div(class: "page-img-container") do
+      image_tag(url_for(page.featured_image), class: "page-responsive-img", alt: page.featured_alt_text, title: page.title, width: "500px")
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,12 @@ module ApplicationHelper
       end
     end
   end
+
+  def feature_image(page:)
+    if page.featured_image.attached?
+      tag.div(class: "page-img-container") do
+        image_tag(url_for(page.featured_image), class: "page-responsive-img", alt: page.featured_alt_text, title: page.title, width: "500px")
+      end
+    end
+  end
 end

--- a/app/views/admin/articles/show.html.haml
+++ b/app/views/admin/articles/show.html.haml
@@ -5,8 +5,7 @@
 %h1.govuk-heading-xl
   = @article.title
 
-%div 
-  = image_tag(url_for(@article.featured_image), width: "500px") if @article.featured_image.attached?
+= feature_image(page: @article)
 
 .govuk-body.gem-c-govspeak
   = translate_markdown(@article.markdown)

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -21,7 +21,7 @@
           <li class="article-card-group__item govuk-!-margin-right-1 govuk-!-margin-left-1">
             <div class="article-card article-card--clickable article-card--link">
                 <div class="article-card-img-container">
-                  <%= image_tag(url_for(article.thumbnail_image), class: "article-card-img") if article.thumbnail_image.attached? %>
+                  <%= image_tag(url_for(article.thumbnail_image), class: "article-card-img", alt: article.thumbnail_alt_text, title: article.title) if article.thumbnail_image.attached? %>
                 </div>
                 <div class="article-card-text">
                   <%= link_to article.title, article_path(article), class: "govuk-link govuk-!-font-size-19 govuk-link--no-visited-state" %>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -21,7 +21,7 @@
           <li class="article-card-group__item govuk-!-margin-right-1 govuk-!-margin-left-1">
             <div class="article-card article-card--clickable article-card--link">
                 <div class="article-card-img-container">
-                  <%= image_tag(url_for(article.thumbnail_image), class: "article-card-img", alt: article.thumbnail_alt_text, title: article.title) if article.thumbnail_image.attached? %>
+                  <%= image_tag(url_for(article.thumbnail_image), class: "article-card-img", alt: article.thumbnail_alt_text, title: article.thumbnail_alt_text) if article.thumbnail_image.attached? %>
                 </div>
                 <div class="article-card-text">
                   <%= link_to article.title, article_path(article), class: "govuk-link govuk-!-font-size-19 govuk-link--no-visited-state" %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -4,9 +4,9 @@
 <div class="govuk-body govuk-!-margin-bottom-2">
   <%= @article.published_at&.strftime("%d %B %Y") %>
 </div>
-<div class="articles-img-container">
-  <%= image_tag(url_for(@article.featured_image), class: "articles-responsive-img") if @article.featured_image.attached? %>
-</div>
+
+<%= feature_image(page: @article) %>
+
 <div class="govuk-body gem-c-govspeak">
   <%= translate_markdown(@article.markdown) %>
 </div>

--- a/app/webpacker/styles/layout-eyfs/landing-page.scss
+++ b/app/webpacker/styles/layout-eyfs/landing-page.scss
@@ -19,7 +19,7 @@
 
 }
 
-//article styles
+//page styles
 
 .articles-landing-page__section--grey {
 
@@ -27,13 +27,13 @@
   box-shadow: 0 -1px 0px 0 rgba(0,0,0,0.2);
 }
 
-.articles-img-container{
+.page-img-container{
   max-height: 360px;
   max-width: 960px;
   overflow: hidden;
 }
 
-.articles-responsive-img{
+.page-responsive-img{
   display: inline-block;
   height: auto;
   width: 960px;


### PR DESCRIPTION
Ticket: [HFEYP-626](https://dfedigital.atlassian.net/browse/HFEYP-626)

Look at feature images on articles in the admin area preview page and on the public portion of the site.
Thumbnail images on the articles page also now have alt text included.  

In addition, the title of the page now shows as the title of the images.

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true

## Product review

### How can someone see it in review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.
