### PR TITLE
HFEYP-652 remove duplicate spec

### DIFF
--- a/spec/features/drafting_and_publishing_spec.rb
+++ b/spec/features/drafting_and_publishing_spec.rb
@@ -21,31 +21,6 @@ RSpec.feature "Drafting and publishing pages", type: :feature do
       expect(saved_page.is_published).to eq(false)
       expect(saved_page.content_page_versions.count).to eq(1)
     end
-
-    it "should delete an unpublished page when the last draft is deleted" do
-      sign_in FactoryBot.create(:user, :editor)
-      attributes = FactoryBot.attributes_for :content_page
-      parent_page = FactoryBot.create(:content_page, :top_level)
-
-      visit "/admin/pages/new?parent_id=#{parent_page.id}"
-
-      page.find_field("content_page[title]").set(attributes[:title])
-      page.find_field("content_page[markdown]").set(attributes[:markdown])
-      page.find_field("content_page[position]").set(rand(10_000))
-
-      page.click_button("Save")
-      saved_page = ContentPage.find_by_title attributes[:title]
-
-      visit versions_admin_content_page_path(saved_page)
-      page.click_link("Delete")
-      # The modal dialog is controlled by a different driver
-      # and the destroy action happens async
-      page.driver.browser.switch_to.alert.accept
-
-      visit "/admin/pages"
-      old_page = ContentPage.find_by_title attributes[:title]
-      expect(old_page).to be(nil)
-    end
   end
 
   describe "editing an existing draft" do

--- a/spec/features/drafting_and_publishing_spec.rb
+++ b/spec/features/drafting_and_publishing_spec.rb
@@ -22,9 +22,4 @@ RSpec.feature "Drafting and publishing pages", type: :feature do
       expect(saved_page.content_page_versions.count).to eq(1)
     end
   end
-
-  describe "editing an existing draft" do
-    it "should apply changes to the existing draft and not create another one" do
-    end
-  end
 end


### PR DESCRIPTION
## Ticket and context

Ticket: [HFEYP-652](https://dfedigital.atlassian.net/browse/HFEYP-652)
## Tech review

Remove spec which intermittently fails and whose functionality is [already tested in another spec](https://github.com/DFE-Digital/early-years-foundation-reform/blob/52d028973df3c9b41aa487b688cd8b400896e90c/spec/requests/content_page_versions_spec.rb#L96). Also remove an empty spec

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true

## Product review

### How can someone see it in review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.