### PR TITLE
Hfeyp 653 asset folder components

### DIFF
--- a/app/controllers/admin/content_assets_controller.rb
+++ b/app/controllers/admin/content_assets_controller.rb
@@ -4,6 +4,7 @@ module Admin
 
     def index
       @content_assets = ContentAsset.all
+      @content_pages = ContentPage.top_level.order_by_position
     end
 
     def show; end

--- a/app/controllers/admin/content_assets_controller.rb
+++ b/app/controllers/admin/content_assets_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class ContentAssetsController < AdminController
     before_action :set_content_asset, only: %i[show edit update destroy]
-    before_action :set_folder_options, only: %i[index new edit]
+    before_action :set_folder_options
 
     def index
       @content_assets = ContentAsset.all

--- a/app/controllers/admin/content_assets_controller.rb
+++ b/app/controllers/admin/content_assets_controller.rb
@@ -60,7 +60,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def content_asset_params
-      params.require(:content_asset).permit(:title, :asset_file, :alt_text, :page_name)
+      params.require(:content_asset).permit(:title, :asset_file, :alt_text, :content_page_id)
     end
   end
 end

--- a/app/controllers/admin/content_assets_controller.rb
+++ b/app/controllers/admin/content_assets_controller.rb
@@ -4,7 +4,6 @@ module Admin
 
     def index
       @content_assets = ContentAsset.all
-      @content_pages = ContentPage.top_level.order_by_position
     end
 
     def show; end

--- a/app/controllers/admin/content_assets_controller.rb
+++ b/app/controllers/admin/content_assets_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   class ContentAssetsController < AdminController
     before_action :set_content_asset, only: %i[show edit update destroy]
-    before_action :set_folder_options
+    before_action :set_folder_options, only: %i[index edit new create update]
 
     def index
       @content_assets = ContentAsset.all

--- a/app/controllers/admin/content_assets_controller.rb
+++ b/app/controllers/admin/content_assets_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class ContentAssetsController < AdminController
     before_action :set_content_asset, only: %i[show edit update destroy]
+    before_action :set_folder_options, only: %i[index new edit]
 
     def index
       @content_assets = ContentAsset.all
@@ -61,6 +62,10 @@ module Admin
     # Only allow a list of trusted parameters through.
     def content_asset_params
       params.require(:content_asset).permit(:title, :asset_file, :alt_text, :content_page_id)
+    end
+
+    def set_folder_options
+      @folder_options = ContentPage.top_level.order_by_position.all + [OpenStruct.new(id: 0, title: "Other")]
     end
   end
 end

--- a/app/controllers/admin/content_assets_controller.rb
+++ b/app/controllers/admin/content_assets_controller.rb
@@ -61,7 +61,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def content_asset_params
-      params.require(:content_asset).permit(:title, :asset_file, :alt_text)
+      params.require(:content_asset).permit(:title, :asset_file, :alt_text, :page_name)
     end
   end
 end

--- a/app/controllers/admin/content_assets_controller.rb
+++ b/app/controllers/admin/content_assets_controller.rb
@@ -65,7 +65,7 @@ module Admin
     end
 
     def set_folder_options
-      @folder_options = ContentPage.top_level.order_by_position.all + [OpenStruct.new(id: 0, title: "Other")]
+      @folder_options = ContentPage.top_level.order_by_position.all + [OpenStruct.new(id: nil, title: "Other")]
     end
   end
 end

--- a/app/helpers/content_pages_helper.rb
+++ b/app/helpers/content_pages_helper.rb
@@ -1,5 +1,0 @@
-module ContentPagesHelper
-  def get_all_content_pages
-    ContentPage.top_level.order_by_position
-  end
-end

--- a/app/helpers/content_pages_helper.rb
+++ b/app/helpers/content_pages_helper.rb
@@ -1,5 +1,5 @@
 module ContentPagesHelper
   def get_all_content_pages
-    @content_pages = ContentPage.top_level.order_by_position
+    ContentPage.top_level.order_by_position
   end
 end

--- a/app/helpers/content_pages_helper.rb
+++ b/app/helpers/content_pages_helper.rb
@@ -1,0 +1,5 @@
+module ContentPagesHelper
+  def get_all_content_pages
+    @content_pages = ContentPage.top_level.order_by_position
+  end
+end

--- a/app/models/content_asset.rb
+++ b/app/models/content_asset.rb
@@ -19,7 +19,7 @@ class ContentAsset < ApplicationRecord
   validate :asset_file_ext_validation
   validates :asset_file, content_type: VALID_CONTENT_TYPE
   validates :asset_file, antivirus: true
-  validates :page_name, presence: true
+  has_one :content_page
 
   def asset_file_ext_validation
     return unless asset_file.attached?

--- a/app/models/content_asset.rb
+++ b/app/models/content_asset.rb
@@ -19,6 +19,7 @@ class ContentAsset < ApplicationRecord
   validate :asset_file_ext_validation
   validates :asset_file, content_type: VALID_CONTENT_TYPE
   validates :asset_file, antivirus: true
+  validates :page_name, presence: true
 
   def asset_file_ext_validation
     return unless asset_file.attached?

--- a/app/models/content_asset.rb
+++ b/app/models/content_asset.rb
@@ -19,7 +19,7 @@ class ContentAsset < ApplicationRecord
   validate :asset_file_ext_validation
   validates :asset_file, content_type: VALID_CONTENT_TYPE
   validates :asset_file, antivirus: true
-  belongs_to :content_page
+  belongs_to :content_page, optional: true
 
   def asset_file_ext_validation
     return unless asset_file.attached?

--- a/app/models/content_asset.rb
+++ b/app/models/content_asset.rb
@@ -19,7 +19,7 @@ class ContentAsset < ApplicationRecord
   validate :asset_file_ext_validation
   validates :asset_file, content_type: VALID_CONTENT_TYPE
   validates :asset_file, antivirus: true
-  has_one :content_page
+  belongs_to :content_page
 
   def asset_file_ext_validation
     return unless asset_file.attached?

--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -3,6 +3,7 @@ class ContentPage < ApplicationRecord
   audited
 
   has_many :content_page_versions
+  has_many :content_assets
 
   scope :top_level, -> { where("parent_id IS NULL") }
   scope :order_by_position, -> { order("position ASC") }

--- a/app/views/admin/content_assets/_form.html.erb
+++ b/app/views/admin/content_assets/_form.html.erb
@@ -13,7 +13,7 @@
   <div class="govuk-form-group">
     <%= form.govuk_text_field :title, width: 'three-quarters' %>
     <%= form.govuk_text_field :alt_text, label: { text: "Alternate text" }, width: 'three-quarters' %>
-    <%= form.govuk_collection_radio_buttons :page_name, get_all_content_pages, :position, :title, legend: { text: 'Page title' } %>
+    <%= form.govuk_collection_radio_buttons :page_name, ContentPage.top_level.order_by_position, :position, :title, legend: { text: 'Page title' } %>
     <%= form.govuk_file_field :asset_file, label: { text: "Asset file" }, width: 'one-half', hint: { text: "Upload an asset file less than 2MB.</br>Valid extensions are PDF, DOC, DOCX, XLS, XLSX, JPG, JPEG, PNG".html_safe} %>
     <p class="govuk-body" id="content_asset_file_size"></p>
   </div>

--- a/app/views/admin/content_assets/_form.html.erb
+++ b/app/views/admin/content_assets/_form.html.erb
@@ -9,7 +9,6 @@
       </ul>
     </div>
   <% end %>
-  
 
   <div class="govuk-form-group">
     <%= form.govuk_text_field :title, width: 'three-quarters' %>

--- a/app/views/admin/content_assets/_form.html.erb
+++ b/app/views/admin/content_assets/_form.html.erb
@@ -9,11 +9,13 @@
       </ul>
     </div>
   <% end %>
+  
 
   <div class="govuk-form-group">
     <%= form.govuk_text_field :title, width: 'three-quarters' %>
     <%= form.govuk_text_field :alt_text, label: { text: "Alternate text" }, width: 'three-quarters' %>
-    <%= form.govuk_collection_radio_buttons :content_page_id, ContentPage.top_level.order_by_position, :id, :title, legend: { text: 'Page title' } %>
+    <%= form.govuk_collection_radio_buttons :content_page_id, @folder_options, :id, :title, legend: { text: 'Section title' } %>
+
     <%= form.govuk_file_field :asset_file, label: { text: "Asset file" }, width: 'one-half', hint: { text: "Upload an asset file less than 2MB.</br>Valid extensions are PDF, DOC, DOCX, XLS, XLSX, JPG, JPEG, PNG".html_safe} %>
     <p class="govuk-body" id="content_asset_file_size"></p>
   </div>

--- a/app/views/admin/content_assets/_form.html.erb
+++ b/app/views/admin/content_assets/_form.html.erb
@@ -11,9 +11,10 @@
   <% end %>
 
   <div class="govuk-form-group">
+    <% get_all_content_pages %>
     <%= form.govuk_text_field :title, width: 'three-quarters' %>
     <%= form.govuk_text_field :alt_text, label: { text: "Alternate text" }, width: 'three-quarters' %>
-    <%= form.govuk_text_field :page_name, label: { text: "Page name" }, width: 'three-quarters' %>
+    <%= form.govuk_collection_radio_buttons :page_name, @content_pages, :position, :title, legend: { text: 'Page title' } %>
     <%= form.govuk_file_field :asset_file, label: { text: "Asset file" }, width: 'one-half', hint: { text: "Upload an asset file less than 2MB.</br>Valid extensions are PDF, DOC, DOCX, XLS, XLSX, JPG, JPEG, PNG".html_safe} %>
     <p class="govuk-body" id="content_asset_file_size"></p>
   </div>

--- a/app/views/admin/content_assets/_form.html.erb
+++ b/app/views/admin/content_assets/_form.html.erb
@@ -11,10 +11,9 @@
   <% end %>
 
   <div class="govuk-form-group">
-    <% get_all_content_pages %>
     <%= form.govuk_text_field :title, width: 'three-quarters' %>
     <%= form.govuk_text_field :alt_text, label: { text: "Alternate text" }, width: 'three-quarters' %>
-    <%= form.govuk_collection_radio_buttons :page_name, @content_pages, :position, :title, legend: { text: 'Page title' } %>
+    <%= form.govuk_collection_radio_buttons :page_name, get_all_content_pages, :position, :title, legend: { text: 'Page title' } %>
     <%= form.govuk_file_field :asset_file, label: { text: "Asset file" }, width: 'one-half', hint: { text: "Upload an asset file less than 2MB.</br>Valid extensions are PDF, DOC, DOCX, XLS, XLSX, JPG, JPEG, PNG".html_safe} %>
     <p class="govuk-body" id="content_asset_file_size"></p>
   </div>

--- a/app/views/admin/content_assets/_form.html.erb
+++ b/app/views/admin/content_assets/_form.html.erb
@@ -13,7 +13,7 @@
   <div class="govuk-form-group">
     <%= form.govuk_text_field :title, width: 'three-quarters' %>
     <%= form.govuk_text_field :alt_text, label: { text: "Alternate text" }, width: 'three-quarters' %>
-    <%= form.govuk_collection_radio_buttons :content_page_id, ContentPage.top_level.order_by_position, :position, :title, legend: { text: 'Page title' } %>
+    <%= form.govuk_collection_radio_buttons :content_page_id, ContentPage.top_level.order_by_position, :id, :title, legend: { text: 'Page title' } %>
     <%= form.govuk_file_field :asset_file, label: { text: "Asset file" }, width: 'one-half', hint: { text: "Upload an asset file less than 2MB.</br>Valid extensions are PDF, DOC, DOCX, XLS, XLSX, JPG, JPEG, PNG".html_safe} %>
     <p class="govuk-body" id="content_asset_file_size"></p>
   </div>

--- a/app/views/admin/content_assets/_form.html.erb
+++ b/app/views/admin/content_assets/_form.html.erb
@@ -13,7 +13,7 @@
   <div class="govuk-form-group">
     <%= form.govuk_text_field :title, width: 'three-quarters' %>
     <%= form.govuk_text_field :alt_text, label: { text: "Alternate text" }, width: 'three-quarters' %>
-    <%= form.govuk_collection_radio_buttons :page_name, ContentPage.top_level.order_by_position, :position, :title, legend: { text: 'Page title' } %>
+    <%= form.govuk_collection_radio_buttons :content_page_id, ContentPage.top_level.order_by_position, :position, :title, legend: { text: 'Page title' } %>
     <%= form.govuk_file_field :asset_file, label: { text: "Asset file" }, width: 'one-half', hint: { text: "Upload an asset file less than 2MB.</br>Valid extensions are PDF, DOC, DOCX, XLS, XLSX, JPG, JPEG, PNG".html_safe} %>
     <p class="govuk-body" id="content_asset_file_size"></p>
   </div>

--- a/app/views/admin/content_assets/_form.html.erb
+++ b/app/views/admin/content_assets/_form.html.erb
@@ -13,6 +13,7 @@
   <div class="govuk-form-group">
     <%= form.govuk_text_field :title, width: 'three-quarters' %>
     <%= form.govuk_text_field :alt_text, label: { text: "Alternate text" }, width: 'three-quarters' %>
+    <%= form.govuk_text_field :page_name, label: { text: "Page name" }, width: 'three-quarters' %>
     <%= form.govuk_file_field :asset_file, label: { text: "Asset file" }, width: 'one-half', hint: { text: "Upload an asset file less than 2MB.</br>Valid extensions are PDF, DOC, DOCX, XLS, XLSX, JPG, JPEG, PNG".html_safe} %>
     <p class="govuk-body" id="content_asset_file_size"></p>
   </div>

--- a/app/views/admin/content_assets/_form.html.erb
+++ b/app/views/admin/content_assets/_form.html.erb
@@ -15,7 +15,6 @@
     <%= form.govuk_text_field :title, width: 'three-quarters' %>
     <%= form.govuk_text_field :alt_text, label: { text: "Alternate text" }, width: 'three-quarters' %>
     <%= form.govuk_collection_radio_buttons :content_page_id, @folder_options, :id, :title, legend: { text: 'Section title' } %>
-
     <%= form.govuk_file_field :asset_file, label: { text: "Asset file" }, width: 'one-half', hint: { text: "Upload an asset file less than 2MB.</br>Valid extensions are PDF, DOC, DOCX, XLS, XLSX, JPG, JPEG, PNG".html_safe} %>
     <p class="govuk-body" id="content_asset_file_size"></p>
   </div>

--- a/app/views/admin/content_assets/_table_body.html.erb
+++ b/app/views/admin/content_assets/_table_body.html.erb
@@ -1,0 +1,13 @@
+<tr class="govuk-table__row">
+  <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), class: 'govuk-!-width-full') %></td>
+  <td class="govuk-table__cell" ><%= content_asset.title %></td>
+  <td class="govuk-table__cell">
+    <%= govuk_button_link_to 'Edit', edit_admin_content_asset_path(content_asset), secondary: true %>
+    <%= button_tag(
+      "Copy to clipboard", 
+      type: 'button', 
+      class: "govuk-button govuk-button--secondary", 
+      onclick: "navigator.clipboard.writeText('#{polymorphic_url(content_asset.asset_file)}')" 
+    ) %>
+  </td>
+</tr>

--- a/app/views/admin/content_assets/_table_header.html.erb
+++ b/app/views/admin/content_assets/_table_header.html.erb
@@ -1,7 +1,0 @@
-<thead class="govuk-table__head">
-  <tr class="govuk-table__row">
-    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Image</th>
-    <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
-    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action</th>
-  </tr>
-</thead>

--- a/app/views/admin/content_assets/_table_header.html.erb
+++ b/app/views/admin/content_assets/_table_header.html.erb
@@ -1,0 +1,7 @@
+<thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Image</th>
+    <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
+    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action</th>
+  </tr>
+</thead>

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -15,8 +15,9 @@
         </thead>
 
         <tbody class="govuk-table__body">
-          <% @content_assets.each do |content_asset| %>
-            <% if content_asset.content_page_id == content_page.position %>
+          <% content_assets = content_page.content_assets %>
+          <% if content_assets %>
+            <% content_assets.each do |content_asset|%>
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), class: 'govuk-!-width-full') %></td>
                 <td class="govuk-table__cell" ><%= content_asset.title %></td>

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -1,6 +1,7 @@
 <h1  class="govuk-heading-l">Assets</h1>
 <%= govuk_button_link_to 'Add asset', new_admin_content_asset_path, class: "govuk-button" %>
 
+<% get_all_content_pages %>
 <%= govuk_accordion do |accordion|
   @content_pages.each do |content_page|
     accordion.section(heading_text: content_page.title) do %>
@@ -16,7 +17,7 @@
 
         <tbody class="govuk-table__body">
           <% @content_assets.each do |content_asset| %>
-            <% if content_asset.page_name == content_page.title %>
+            <% if content_asset.page_name.to_i == content_page.position %>
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), class: 'govuk-!-width-full') %></td>
                 <td class="govuk-table__cell" ><%= content_asset.title %></td>

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -1,9 +1,8 @@
 <h1  class="govuk-heading-l">Assets</h1>
 <%= govuk_button_link_to 'Add asset', new_admin_content_asset_path, class: "govuk-button" %>
 
-<% get_all_content_pages %>
 <%= govuk_accordion do |accordion|
-  @content_pages.each do |content_page|
+  get_all_content_pages.each do |content_page|
     accordion.section(heading_text: content_page.title) do %>
 
       <table class="govuk-table">

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -1,9 +1,9 @@
 <h1  class="govuk-heading-l">Assets</h1>
+<%= govuk_button_link_to 'Add asset', new_admin_content_asset_path, class: "govuk-button" %>
 
 <%= govuk_accordion do |accordion|
   @content_pages.each do |content_page|
     accordion.section(heading_text: content_page.title) do %>
-      <%= govuk_button_link_to 'Add asset', new_admin_content_asset_path, :class => "govuk-button" %>
 
       <table class="govuk-table">
         <thead class="govuk-table__head">
@@ -16,12 +16,13 @@
 
         <tbody class="govuk-table__body">
           <% @content_assets.each do |content_asset| %>
-            <% if content_asset.page_name == content_page.title%>
+            <% if content_asset.page_name == content_page.title %>
               <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), :class=>'govuk-!-width-full') %></td>
+                <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), class: 'govuk-!-width-full') %></td>
                 <td class="govuk-table__cell" ><%= content_asset.title %></td>
                 <td class="govuk-table__cell">
                   <%= govuk_button_link_to 'Edit', edit_admin_content_asset_path(content_asset), secondary: true %>
+                  <%= button_tag "Copy to clipboard", type: 'button', class: "govuk-button govuk-button--secondary", onClick: "navigator.clipboard.writeText('#{polymorphic_url(content_asset.asset_file)}')" %>
                 </td>
               </tr>
             <% end %>

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -4,7 +4,6 @@
 <%= govuk_accordion do |accordion|
   ContentPage.top_level.order_by_position.each do |content_page|
     accordion.section(heading_text: content_page.title) do %>
-
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
@@ -37,6 +36,47 @@
       </table>
     <% end %>
   <% end %>
+  <%= accordion.section(heading_text: "Other") do %>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Image</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action</th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        <% @content_assets.each do |content_asset| if content_asset.content_page == nil %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), class: 'govuk-!-width-full') %></td>
+            <td class="govuk-table__cell" ><%= content_asset.title %></td>
+            <td class="govuk-table__cell">
+              <%= govuk_button_link_to 'Edit', edit_admin_content_asset_path(content_asset), secondary: true %>
+              <%= button_tag(
+                "Copy to clipboard", 
+                type: 'button', 
+                class: "govuk-button govuk-button--secondary", 
+                onclick: "navigator.clipboard.writeText('#{polymorphic_url(content_asset.asset_file)}')" 
+              ) %>
+            </td>
+          </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+
+
+
+
+
+
+
+
+
+
 <% end %>
 
 <br>

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -16,7 +16,7 @@
 
         <tbody class="govuk-table__body">
           <% @content_assets.each do |content_asset| %>
-            <% if content_asset.page_name.to_i == content_page.position %>
+            <% if content_asset.content_page_id == content_page.position %>
               <tr class="govuk-table__row">
                 <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), class: 'govuk-!-width-full') %></td>
                 <td class="govuk-table__cell" ><%= content_asset.title %></td>

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -1,25 +1,35 @@
 <h1  class="govuk-heading-l">Assets</h1>
 
-<%= link_to 'Add asset', new_admin_content_asset_path, :class => "govuk-button" %>
+<%= govuk_accordion do |accordion|
+accordion.section(heading_text: "Communication and langauge", expanded: true) do %>
+  <%= govuk_button_link_to 'Add asset', new_admin_content_asset_path, :class => "govuk-button" %>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header">Title</th>
-      <th scope="col" class="govuk-table__header">Alt Text</th>
-      <th scope="col" class="govuk-table__header"></th>
-    </tr>
-  </thead>
-
-  <tbody class="govuk-table__body">
-    <% @content_assets.each do |content_asset| %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell" ><%= content_asset.title %></td>
-        <td class="govuk-table__cell" ><%= content_asset.alt_text %></td>
-        <td class="govuk-table__cell"><%= link_to 'Edit', edit_admin_content_asset_path(content_asset), { :class => "govuk-link" } %></td>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Image</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Name</th>
+        <th scope="col" class="govuk-table__header">Action</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+
+    <tbody class="govuk-table__body">
+      <% @content_assets.each do |content_asset| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), :class=>'govuk-!-width-full') %></td>
+          <td class="govuk-table__cell" ><%= content_asset.title %></td>
+          <td class="govuk-table__cell">
+            <%= govuk_button_link_to 'Edit', edit_admin_content_asset_path(content_asset), secondary: true %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end
+
+accordion.section(heading_text: "Physical development") { tag.p("Two content") }
+
+accordion.section(heading_text: "Personal, social and emotional development") { tag.p("Three content") }
+end %>
 
 <br>

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -1,35 +1,33 @@
 <h1  class="govuk-heading-l">Assets</h1>
 
 <%= govuk_accordion do |accordion|
-accordion.section(heading_text: "Communication and langauge", expanded: true) do %>
-  <%= govuk_button_link_to 'Add asset', new_admin_content_asset_path, :class => "govuk-button" %>
+  @content_pages.each do |content_page|
+    accordion.section(heading_text: content_page.title) do %>
+      <%= govuk_button_link_to 'Add asset', new_admin_content_asset_path, :class => "govuk-button" %>
 
-  <table class="govuk-table">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Image</th>
-        <th scope="col" class="govuk-table__header govuk-!-width-two-thirds">Name</th>
-        <th scope="col" class="govuk-table__header">Action</th>
-      </tr>
-    </thead>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Image</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action</th>
+          </tr>
+        </thead>
 
-    <tbody class="govuk-table__body">
-      <% @content_assets.each do |content_asset| %>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), :class=>'govuk-!-width-full') %></td>
-          <td class="govuk-table__cell" ><%= content_asset.title %></td>
-          <td class="govuk-table__cell">
-            <%= govuk_button_link_to 'Edit', edit_admin_content_asset_path(content_asset), secondary: true %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% end
-
-accordion.section(heading_text: "Physical development") { tag.p("Two content") }
-
-accordion.section(heading_text: "Personal, social and emotional development") { tag.p("Three content") }
-end %>
+        <tbody class="govuk-table__body">
+          <% @content_assets.each do |content_asset| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), :class=>'govuk-!-width-full') %></td>
+              <td class="govuk-table__cell" ><%= content_asset.title %></td>
+              <td class="govuk-table__cell">
+                <%= govuk_button_link_to 'Edit', edit_admin_content_asset_path(content_asset), secondary: true %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
+  <% end %>
+<% end %>
 
 <br>

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -5,31 +5,12 @@
   ContentPage.top_level.order_by_position.each do |content_page|
     accordion.section(heading_text: content_page.title) do %>
       <table class="govuk-table">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Image</th>
-            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
-            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action</th>
-          </tr>
-        </thead>
-
+        <%= render partial: 'table_header' %>
         <tbody class="govuk-table__body">
           <% content_assets = content_page.content_assets %>
           <% if content_assets %>
             <% content_assets.each do |content_asset|%>
-              <tr class="govuk-table__row">
-                <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), class: 'govuk-!-width-full') %></td>
-                <td class="govuk-table__cell" ><%= content_asset.title %></td>
-                <td class="govuk-table__cell">
-                  <%= govuk_button_link_to 'Edit', edit_admin_content_asset_path(content_asset), secondary: true %>
-                  <%= button_tag(
-                    "Copy to clipboard", 
-                    type: 'button', 
-                    class: "govuk-button govuk-button--secondary", 
-                    onclick: "navigator.clipboard.writeText('#{polymorphic_url(content_asset.asset_file)}')" 
-                  ) %>
-                </td>
-              </tr>
+              <%= render partial: 'table_body', locals: { content_asset: content_asset } %>
             <% end %>
           <% end %>
         </tbody>
@@ -38,45 +19,15 @@
   <% end %>
   <%= accordion.section(heading_text: "Other") do %>
     <table class="govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Image</th>
-          <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
-          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action</th>
-        </tr>
-      </thead>
-
+      <%= render partial: 'table_header' %>
       <tbody class="govuk-table__body">
         <% @content_assets.each do |content_asset| if content_asset.content_page == nil %>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), class: 'govuk-!-width-full') %></td>
-            <td class="govuk-table__cell" ><%= content_asset.title %></td>
-            <td class="govuk-table__cell">
-              <%= govuk_button_link_to 'Edit', edit_admin_content_asset_path(content_asset), secondary: true %>
-              <%= button_tag(
-                "Copy to clipboard", 
-                type: 'button', 
-                class: "govuk-button govuk-button--secondary", 
-                onclick: "navigator.clipboard.writeText('#{polymorphic_url(content_asset.asset_file)}')" 
-              ) %>
-            </td>
-          </tr>
+          <%= render partial: 'table_body', locals: { content_asset: content_asset } %>
           <% end %>
         <% end %>
       </tbody>
     </table>
   <% end %>
-
-
-
-
-
-
-
-
-
-
-
 <% end %>
 
 <br>

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -2,31 +2,32 @@
 <%= govuk_button_link_to 'Add asset', new_admin_content_asset_path, class: "govuk-button" %>
 
 <%= govuk_accordion do |accordion|
-  ContentPage.top_level.order_by_position.each do |content_page|
+  @folder_options.each do |content_page|
     accordion.section(heading_text: content_page.title) do %>
       <table class="govuk-table">
-        <%= render partial: 'table_header' %>
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Image</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Name</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Action</th>
+          </tr>
+        </thead>
         <tbody class="govuk-table__body">
           <% content_assets = content_page.content_assets %>
           <% if content_assets %>
             <% content_assets.each do |content_asset|%>
               <%= render partial: 'table_body', locals: { content_asset: content_asset } %>
             <% end %>
+          <% else %>
+            <% @content_assets.each do |content_asset| %>
+              <% if content_asset.content_page == nil %>
+                <%= render partial: 'table_body', locals: { content_asset: content_asset } %>
+              <% end %>
+            <% end %>
           <% end %>
         </tbody>
       </table>
     <% end %>
-  <% end %>
-  <%= accordion.section(heading_text: "Other") do %>
-    <table class="govuk-table">
-      <%= render partial: 'table_header' %>
-      <tbody class="govuk-table__body">
-        <% @content_assets.each do |content_asset| if content_asset.content_page == nil %>
-          <%= render partial: 'table_body', locals: { content_asset: content_asset } %>
-          <% end %>
-        <% end %>
-      </tbody>
-    </table>
   <% end %>
 <% end %>
 

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -16,13 +16,15 @@
 
         <tbody class="govuk-table__body">
           <% @content_assets.each do |content_asset| %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), :class=>'govuk-!-width-full') %></td>
-              <td class="govuk-table__cell" ><%= content_asset.title %></td>
-              <td class="govuk-table__cell">
-                <%= govuk_button_link_to 'Edit', edit_admin_content_asset_path(content_asset), secondary: true %>
-              </td>
-            </tr>
+            <% if content_asset.page_name == content_page.title%>
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell"><%= image_tag(url_for(content_asset.asset_file), :class=>'govuk-!-width-full') %></td>
+                <td class="govuk-table__cell" ><%= content_asset.title %></td>
+                <td class="govuk-table__cell">
+                  <%= govuk_button_link_to 'Edit', edit_admin_content_asset_path(content_asset), secondary: true %>
+                </td>
+              </tr>
+            <% end %>
           <% end %>
         </tbody>
       </table>

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -16,12 +16,12 @@
           <% content_assets = content_page.content_assets %>
           <% if content_assets %>
             <% content_assets.each do |content_asset|%>
-              <%= render partial: 'table_body', locals: { content_asset: content_asset } %>
+              <%= render 'table_body', content_asset: content_asset %>
             <% end %>
           <% else %>
             <% @content_assets.each do |content_asset| %>
-              <% if content_asset.content_page == nil %>
-                <%= render partial: 'table_body', locals: { content_asset: content_asset } %>
+              <% if content_asset.content_page.nil? %>
+                <%= render 'table_body', content_asset: content_asset %>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/admin/content_assets/index.html.erb
+++ b/app/views/admin/content_assets/index.html.erb
@@ -2,7 +2,7 @@
 <%= govuk_button_link_to 'Add asset', new_admin_content_asset_path, class: "govuk-button" %>
 
 <%= govuk_accordion do |accordion|
-  get_all_content_pages.each do |content_page|
+  ContentPage.top_level.order_by_position.each do |content_page|
     accordion.section(heading_text: content_page.title) do %>
 
       <table class="govuk-table">
@@ -22,7 +22,12 @@
                 <td class="govuk-table__cell" ><%= content_asset.title %></td>
                 <td class="govuk-table__cell">
                   <%= govuk_button_link_to 'Edit', edit_admin_content_asset_path(content_asset), secondary: true %>
-                  <%= button_tag "Copy to clipboard", type: 'button', class: "govuk-button govuk-button--secondary", onClick: "navigator.clipboard.writeText('#{polymorphic_url(content_asset.asset_file)}')" %>
+                  <%= button_tag(
+                    "Copy to clipboard", 
+                    type: 'button', 
+                    class: "govuk-button govuk-button--secondary", 
+                    onclick: "navigator.clipboard.writeText('#{polymorphic_url(content_asset.asset_file)}')" 
+                  ) %>
                 </td>
               </tr>
             <% end %>

--- a/app/webpacker/custom/admin.js
+++ b/app/webpacker/custom/admin.js
@@ -19,5 +19,5 @@ export function copyToClipboard() {
   var copyText = document.getElementById("clipboard_content");
   copyText.select();
   copyText.setSelectionRange(0, 99999); /* For mobile devices */
-  document.execCommand("copy");
+  navigator.clipboard.writeText(copyText.value);
 }

--- a/db/migrate/20220126155222_add_page_name_to_content_assets.rb
+++ b/db/migrate/20220126155222_add_page_name_to_content_assets.rb
@@ -1,0 +1,5 @@
+class AddPageNameToContentAssets < ActiveRecord::Migration[6.1]
+  def change
+    add_column :content_assets, :page_name, :string
+  end
+end

--- a/db/migrate/20220201145322_add_content_page_id_to_content_assets.rb
+++ b/db/migrate/20220201145322_add_content_page_id_to_content_assets.rb
@@ -1,0 +1,5 @@
+class AddContentPageIdToContentAssets < ActiveRecord::Migration[6.1]
+  def change
+    add_column :content_assets, :content_page_id, :integer
+  end
+end

--- a/db/migrate/20220201161815_remove_page_name_from_content_assets.rb
+++ b/db/migrate/20220201161815_remove_page_name_from_content_assets.rb
@@ -1,0 +1,5 @@
+class RemovePageNameFromContentAssets < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :content_assets, :page_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_26_155222) do
+ActiveRecord::Schema.define(version: 2022_02_01_145322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,7 @@ ActiveRecord::Schema.define(version: 2022_01_26_155222) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "alt_text", default: "", null: false
     t.string "page_name"
+    t.integer "content_page_id"
   end
 
   create_table "content_blocks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_01_145322) do
+ActiveRecord::Schema.define(version: 2022_02_01_161815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,7 +92,6 @@ ActiveRecord::Schema.define(version: 2022_02_01_145322) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "alt_text", default: "", null: false
-    t.string "page_name"
     t.integer "content_page_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_23_142331) do
+ActiveRecord::Schema.define(version: 2022_01_26_155222) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 2021_11_23_142331) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "alt_text", default: "", null: false
+    t.string "page_name"
   end
 
   create_table "content_blocks", force: :cascade do |t|

--- a/spec/factories/content_assets.rb
+++ b/spec/factories/content_assets.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :content_asset do
     title { Faker::Lorem.sentence(word_count: 4).to_s }
     alt_text { Faker::Lorem.sentence(word_count: 4).to_s }
-    content_page_id { rand(1..100) }
+    content_page
     asset_file { Rack::Test::UploadedFile.new("spec/fixtures/files/sample.jpeg", "image/jpeg") }
   end
 end

--- a/spec/factories/content_assets.rb
+++ b/spec/factories/content_assets.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :content_asset do
     title { Faker::Lorem.sentence(word_count: 4).to_s }
     alt_text { Faker::Lorem.sentence(word_count: 4).to_s }
-    page_name { Faker::Lorem.sentence(word_count: 4).to_s }
+    content_page_id { rand(1..100) }
     asset_file { Rack::Test::UploadedFile.new("spec/fixtures/files/sample.jpeg", "image/jpeg") }
   end
 end

--- a/spec/factories/content_assets.rb
+++ b/spec/factories/content_assets.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :content_asset do
     title { Faker::Lorem.sentence(word_count: 4).to_s }
     alt_text { Faker::Lorem.sentence(word_count: 4).to_s }
+    page_name { Faker::Lorem.sentence(word_count: 4).to_s }
     asset_file { Rack::Test::UploadedFile.new("spec/fixtures/files/sample.jpeg", "image/jpeg") }
   end
 end

--- a/spec/models/content_asset_spec.rb
+++ b/spec/models/content_asset_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ContentAsset, type: :model do
     before(:each) do
       content_asset.title = "Title"
       content_asset.alt_text = "Sample Alt Text"
-      content_asset.content_page_id = 1
+      content_asset.content_page = create(:content_page)
       content_asset.asset_file.attach(io: File.open(file_fixture("sample.jpeg")), filename: "sample.jpeg", content_type: "image/jpeg")
       content_asset.save!
     end

--- a/spec/models/content_asset_spec.rb
+++ b/spec/models/content_asset_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ContentAsset, type: :model do
     before(:each) do
       content_asset.title = "Title"
       content_asset.alt_text = "Sample Alt Text"
-      content_asset.page_name = "Sample Page Name"
+      content_asset.content_page_id = 1
       content_asset.asset_file.attach(io: File.open(file_fixture("sample.jpeg")), filename: "sample.jpeg", content_type: "image/jpeg")
       content_asset.save!
     end

--- a/spec/models/content_asset_spec.rb
+++ b/spec/models/content_asset_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe ContentAsset, type: :model do
     before(:each) do
       content_asset.title = "Title"
       content_asset.alt_text = "Sample Alt Text"
+      content_asset.page_name = "Sample Page Name"
       content_asset.asset_file.attach(io: File.open(file_fixture("sample.jpeg")), filename: "sample.jpeg", content_type: "image/jpeg")
       content_asset.save!
     end

--- a/spec/views/admin/content_assets/edit.html.erb_spec.rb
+++ b/spec/views/admin/content_assets/edit.html.erb_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe "admin/content_assets/edit", type: :view do
   before(:each) do
     @content_asset = FactoryBot.create(:content_asset)
+    @folder_options = [
+      FactoryBot.create(:content_page),
+      FactoryBot.create(:content_page),
+    ]
   end
 
   it "renders the edit content_asset form" do

--- a/spec/views/admin/content_assets/index.html.erb_spec.rb
+++ b/spec/views/admin/content_assets/index.html.erb_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe "admin/content_assets/index", type: :view do
       FactoryBot.create(:content_asset, title: "title 1", alt_text: "hello"),
       FactoryBot.create(:content_asset, title: "title 2", alt_text: "hello 2 u"),
     ]
+    @folder_options = [
+      FactoryBot.create(:content_page),
+      FactoryBot.create(:content_page),
+    ]
   end
 
   it "renders a list of content_assets" do

--- a/spec/views/admin/content_assets/index.html.erb_spec.rb
+++ b/spec/views/admin/content_assets/index.html.erb_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe "admin/content_assets/index", type: :view do
   before(:each) do
     @content_assets = [
-      FactoryBot.create(:content_asset, title: "title 1", alt_text: "hello", content_page_id: 1),
-      FactoryBot.create(:content_asset, title: "title 2", alt_text: "hello 2 u", content_page_id: 2),
+      FactoryBot.create(:content_asset, title: "title 1", alt_text: "hello"),
+      FactoryBot.create(:content_asset, title: "title 2", alt_text: "hello 2 u"),
     ]
   end
 

--- a/spec/views/admin/content_assets/index.html.erb_spec.rb
+++ b/spec/views/admin/content_assets/index.html.erb_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe "admin/content_assets/index", type: :view do
   before(:each) do
     @content_assets = [
-      FactoryBot.create(:content_asset, title: "title 1", alt_text: "hello", page_name: "page name 1"),
-      FactoryBot.create(:content_asset, title: "title 2", alt_text: "hello 2 u", page_name: "page name 2"),
+      FactoryBot.create(:content_asset, title: "title 1", alt_text: "hello", content_page_id: 1),
+      FactoryBot.create(:content_asset, title: "title 2", alt_text: "hello 2 u", content_page_id: 2),
     ]
   end
 
@@ -13,7 +13,7 @@ RSpec.describe "admin/content_assets/index", type: :view do
     @content_assets.each do |asset|
       rendered.include? asset.title
       rendered.include? asset.alt_text
-      rendered.include? asset.page_name
+      rendered.include? asset.content_page_id.to_s
     end
   end
 end

--- a/spec/views/admin/content_assets/index.html.erb_spec.rb
+++ b/spec/views/admin/content_assets/index.html.erb_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe "admin/content_assets/index", type: :view do
   before(:each) do
     @content_assets = [
-      FactoryBot.create(:content_asset, title: "title 1", alt_text: "hello"),
-      FactoryBot.create(:content_asset, title: "title 2", alt_text: "hello 2 u"),
+      FactoryBot.create(:content_asset, title: "title 1", alt_text: "hello", page_name: "page name 1"),
+      FactoryBot.create(:content_asset, title: "title 2", alt_text: "hello 2 u", page_name: "page name 2"),
     ]
   end
 
@@ -13,6 +13,7 @@ RSpec.describe "admin/content_assets/index", type: :view do
     @content_assets.each do |asset|
       rendered.include? asset.title
       rendered.include? asset.alt_text
+      rendered.include? asset.page_name
     end
   end
 end

--- a/spec/views/admin/content_assets/new.html.erb_spec.rb
+++ b/spec/views/admin/content_assets/new.html.erb_spec.rb
@@ -3,10 +3,7 @@ require "rails_helper"
 RSpec.describe "admin/content_assets/new", type: :view do
   before(:each) do
     assign(:content_asset, FactoryBot.build(:content_asset))
-    @folder_options = [
-      FactoryBot.create(:content_page),
-      FactoryBot.create(:content_page),
-    ]
+    @folder_options = create_list(:content_page, 2)
   end
 
   it "renders new content_asset form" do

--- a/spec/views/admin/content_assets/new.html.erb_spec.rb
+++ b/spec/views/admin/content_assets/new.html.erb_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe "admin/content_assets/new", type: :view do
   before(:each) do
     assign(:content_asset, FactoryBot.build(:content_asset))
+    @folder_options = [
+      FactoryBot.create(:content_page),
+      FactoryBot.create(:content_page),
+    ]
   end
 
   it "renders new content_asset form" do


### PR DESCRIPTION
## Ticket and context

Ticket: [HFEYP-653](https://dfedigital.atlassian.net/browse/HFEYP-653)
## Tech review

- Added a column to the content asset model called 'page_name'
- Added radio buttons to form to edit asset page to set correct page name
- Added accordion to asset page, which displays a section for each content page title
- Added a copy link button to each image

### Code quality checks
- [ ] All commit messages are meaningful and true

## Product review
### Is there anything that the product reviewer should know?
The design hasn't been followed exactly for a few reasons:
- the prototype is quite old
- the govuk accordion design has changed
- some radio buttons for selection needed to be added to the edit page to make it make sense

### How can someone see it in review app?
1. Click [the link to review app](https://eyfs-cms-review-pr-586.london.cloudapps.digital/admin/assets)
2. Add an asset. Select which accordion section it should be in by selecting the 'page title'.
3. Verify that it is in the correct section.
4. Edit the page title and verify that it moves to the correct section