### PR TITLE
pin chromedriver version

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,11 @@ require "capybara/rspec"
 require "axe-rspec"
 require "webdrivers/chromedriver"
 
+# Pinned version of chromedriver as newer version was causing an error:
+# 'unknown error: Cannot construct KeyEvent from non-typeable key'
+# To be removed when the error is fixed
+Webdrivers::Chromedriver.required_version = '97.0.4692.71'
+
 SimpleCov.start
 
 # This configuration seems to work well in CI environments:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,9 +5,9 @@ require "axe-rspec"
 require "webdrivers/chromedriver"
 
 # Pinned version of chromedriver as newer version was causing an error:
-# 'unknown error: Cannot construct KeyEvent from non-typeable key'
+# "unknown error: Cannot construct KeyEvent from non-typeable key"
 # To be removed when the error is fixed
-Webdrivers::Chromedriver.required_version = '97.0.4692.71'
+Webdrivers::Chromedriver.required_version = "97.0.4692.71"
 
 SimpleCov.start
 


### PR DESCRIPTION
No ticket. This task is to pin version of chromedriver as the latest version is causing errors with specs:
```
Selenium::WebDriver::Error::UnknownError:
       unknown error: Cannot construct KeyEvent from non-typeable key
         (Session info: headless chrome=98.0.4758.80)
```
This code should be removed when the error is fixed