### PR TITLE
Hfeyp 617 content list print button

### DIFF
--- a/app/controllers/admin/content_page_versions_controller.rb
+++ b/app/controllers/admin/content_page_versions_controller.rb
@@ -37,6 +37,7 @@ module Admin
     def preview_of_draft
       @page = ContentPage.new(title: @content_page_version.title,
                               markdown: @content_page_version.markdown,
+                              content_list: @content_page_version.content_list,
                               position: 22,
                               description: @content_page_version.description,
                               previous_id: @content_page_version.content_page.id,
@@ -49,6 +50,7 @@ module Admin
       @page = @content_page_version.content_page
       @page.update!(
         markdown: @content_page_version.markdown,
+        content_list: @content_page_version.content_list,
         is_published: true,
         author: current_user.name,
         title: @content_page_version.title,
@@ -70,7 +72,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def content_page_version_params
-      params.require(:content_page_version).permit(:title, :markdown, :author, :description)
+      params.require(:content_page_version).permit(:title, :markdown, :content_list, :author, :description)
     end
   end
 end

--- a/app/controllers/admin/content_pages_controller.rb
+++ b/app/controllers/admin/content_pages_controller.rb
@@ -27,9 +27,10 @@ module Admin
       begin
         authorize @content_page, :create?
 
-        if @content_page.save
+        if @content_page.save!
           redirect_to "#{admin_content_page_path(@content_page)}/versions", notice: "A new version was successfully created"
         else
+          puts "Rails consoleeeee"
           render :new
         end
       rescue Pundit::NotAuthorizedError
@@ -60,6 +61,7 @@ module Admin
       # ContentPage validation, before the same values are used to
       # create the ContentPageVersion
       @content_page.markdown = content_page_params[:markdown]
+      @content_page.content_list = content_page_params[:content_list]
       if content_page_params[:title]
         @content_page.title = content_page_params[:title]
       end
@@ -67,6 +69,7 @@ module Admin
       if @content_page.valid?
         ContentPageVersion.create!(title: @content_page.title,
                                    markdown: content_page_params[:markdown],
+                                   content_list: content_page_params[:content_list],
                                    author: current_user.name,
                                    content_page: @content_page,
                                    description: content_page_params[:description])
@@ -105,6 +108,7 @@ module Admin
       @content_page.update!(is_published: false)
       ContentPageVersion.create!(title: @content_page.title,
                                  markdown: @content_page.markdown,
+                                 content_list: @content_page.content_list,
                                  author: current_user.name,
                                  content_page: @content_page,
                                  description: @content_page.description)
@@ -121,7 +125,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def content_page_params
-      params.require(:content_page).permit(:title, :markdown, :parent_id, :position, :description)
+      params.require(:content_page).permit(:title, :markdown, :content_list, :parent_id, :position, :description)
     end
   end
 end

--- a/app/controllers/admin/content_pages_controller.rb
+++ b/app/controllers/admin/content_pages_controller.rb
@@ -27,10 +27,9 @@ module Admin
       begin
         authorize @content_page, :create?
 
-        if @content_page.save!
+        if @content_page.save
           redirect_to "#{admin_content_page_path(@content_page)}/versions", notice: "A new version was successfully created"
         else
-          puts "Rails consoleeeee"
           render :new
         end
       rescue Pundit::NotAuthorizedError

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -30,4 +30,10 @@ module ContentHelper
 
     translate_markdown(html_to_use)
   end
+
+  def print_button(*additional_classes)
+    button = '<button class="govuk-link gem-c-print-link__button" onclick="window.print()" data-module="print-link" >Print this page</button>'.html_safe
+    classes = ["gem-c-print-link", "print-button"] + additional_classes
+    content_tag :div, button, class: classes
+  end
 end

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -38,7 +38,7 @@ module ContentHelper
   end
 
   def govuk_input_classes(input_type, errors: nil)
-    classes = ["govuk-input"]
+    classes = %w[govuk-input]
     classes << "govuk-#{input_type}"
     classes << "govuk-input--error" if errors.present?
     classes

--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -36,4 +36,11 @@ module ContentHelper
     classes = ["gem-c-print-link", "print-button"] + additional_classes
     content_tag :div, button, class: classes
   end
+
+  def govuk_input_classes(input_type, errors: nil)
+    classes = ["govuk-input"]
+    classes << "govuk-#{input_type}"
+    classes << "govuk-input--error" if errors.present?
+    classes
+  end
 end

--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -89,17 +89,8 @@ class ContentPage < ApplicationRecord
       end
 
       page_order.each_with_index do |page, index|
-        page.next_id = if page == page_order.last
-                         page_order.first.id
-                       else
-                         page_order[index + 1].id
-                       end
-
-        page.previous_id = if page == page_order.first
-                             page_order.last.id
-                           else
-                             page_order[index - 1].id
-                           end
+        page.next_id = page_order[index + 1].id unless page == page_order.last
+        page.previous_id = page_order[index - 1].id unless page == page_order.first
         page.save!
       end
     end

--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -15,7 +15,6 @@ class ContentPage < ApplicationRecord
   validates :title, format: { with: ONLY_ALPHA_NUMERIC_COMMA_HYPHEN_SPACE_AND_ROUND_BRACES, message: TITLE_FORMAT_ERROR_MESSAGE }
   validates :title, presence: true, uniqueness: true
   validates :markdown, presence: true
-  validates :content_list, presence: true
   validates :description, length: { maximum: 254 }
 
   validates :position, presence: true, numericality: { only_integer: true }, uniqueness: { scope: :parent_id }

--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -15,6 +15,7 @@ class ContentPage < ApplicationRecord
   validates :title, format: { with: ONLY_ALPHA_NUMERIC_COMMA_HYPHEN_SPACE_AND_ROUND_BRACES, message: TITLE_FORMAT_ERROR_MESSAGE }
   validates :title, presence: true, uniqueness: true
   validates :markdown, presence: true
+  validates :content_list, presence: true
   validates :description, length: { maximum: 254 }
 
   validates :position, presence: true, numericality: { only_integer: true }, uniqueness: { scope: :parent_id }
@@ -29,6 +30,7 @@ class ContentPage < ApplicationRecord
   def create_first_version
     ContentPageVersion.create!(title: title,
                                markdown: markdown,
+                               content_list: content_list,
                                content_page_id: id,
                                author: author,
                                description: description)
@@ -88,8 +90,17 @@ class ContentPage < ApplicationRecord
       end
 
       page_order.each_with_index do |page, index|
-        page.next_id = page_order[index + 1].id unless page == page_order.last
-        page.previous_id = page_order[index - 1].id unless page == page_order.first
+        page.next_id = if page == page_order.last
+                         page_order.first.id
+                       else
+                         page_order[index + 1].id
+                       end
+
+        page.previous_id = if page == page_order.first
+                             page_order.last.id
+                           else
+                             page_order[index - 1].id
+                           end
         page.save!
       end
     end

--- a/app/models/content_page_version.rb
+++ b/app/models/content_page_version.rb
@@ -8,6 +8,7 @@ class ContentPageVersion < ApplicationRecord
   validates :title, format: { with: ContentPage::ONLY_ALPHA_NUMERIC_COMMA_HYPHEN_SPACE_AND_ROUND_BRACES, message: ContentPage::TITLE_FORMAT_ERROR_MESSAGE }
   validates :title, presence: true
   validates :markdown, presence: true
+  validates :content_list, presence: true
   validates :description, length: { maximum: 254 }
 
   delegate :parent, :parent_id, to: :content_page, allow_nil: true

--- a/app/models/content_page_version.rb
+++ b/app/models/content_page_version.rb
@@ -8,7 +8,6 @@ class ContentPageVersion < ApplicationRecord
   validates :title, format: { with: ContentPage::ONLY_ALPHA_NUMERIC_COMMA_HYPHEN_SPACE_AND_ROUND_BRACES, message: ContentPage::TITLE_FORMAT_ERROR_MESSAGE }
   validates :title, presence: true
   validates :markdown, presence: true
-  validates :content_list, presence: true
   validates :description, length: { maximum: 254 }
 
   delegate :parent, :parent_id, to: :content_page, allow_nil: true

--- a/app/views/admin/content_page_versions/_form.html.erb
+++ b/app/views/admin/content_page_versions/_form.html.erb
@@ -12,17 +12,20 @@
                set its own id, and the GOVUKDesignSystemFormBuilder hijacks it -->
           <div class="govuk-form-group gem-c-govspeak">
 
-            <%= form.text_area :content_list, id: 'content-list-editor', rows: 8, cols: 35, class: 'govuk-input govuk-textarea', label: {text: "Table of contents"} %>
+            <label id="content-list-hint" for="content-list-editor" class="govuk-label">
+              Table of contents
+            </label>
+            <%= form.text_area :content_list, id: 'content-list-editor', rows: 8, cols: 35, class: 'govuk-input govuk-textarea' %>
 
             <label id="markdown-hint" for="markdown-editor" class="govuk-label">
               Content
             </label>
+
             <% if @content_page_version&.errors[:markdown].present? %>
               <span class="govuk-error-message"><%= @content_page_version.errors[:markdown][0] %></span>
             <% end %>
-            <% text_area_class_markdown = (@content_page_version&.errors[:markdown].present?) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
 
-            <%= form.text_area :markdown, :id => 'markdown-editor', :rows => 20, :cols => 35,  :class => text_area_class_markdown %>
+            <%= form.text_area :markdown, :id => 'markdown-editor', :rows => 20, :cols => 35,  :class => govuk_input_classes(:textarea, errors: @content_page_version.errors[:markdown]) %>
             
             <%= form.govuk_text_area :description, label: {text: "Meta Description"} %>
           </div>

--- a/app/views/admin/content_page_versions/_form.html.erb
+++ b/app/views/admin/content_page_versions/_form.html.erb
@@ -52,7 +52,7 @@
         <div id='content-list-render' class='gem-c-govspeak'>
           <%= translate_markdown(@content_page_version.content_list) %>
         </div>
-        <div id='markdown-render' class='gem-c-govspeak'>
+        <div id='markdown-render' class='gem-c-govspeak govuk-!-margin-top-5'>
           <%= translate_markdown(@content_page_version.markdown) %>
         </div>
     </div>

--- a/app/views/admin/content_page_versions/_form.html.erb
+++ b/app/views/admin/content_page_versions/_form.html.erb
@@ -4,7 +4,7 @@
       <p class="govuk-heading-m">Details</p>
       <%= form_with(model: [:admin, :content_page, @content_page_version], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
         <fieldset class="govuk-fieldset">
-          <%= form.govuk_error_summary order: %i[title markdown content_list]  %>
+          <%= form.govuk_error_summary order: %i[title markdown]  %>
 
           <%= form.govuk_text_field :title, label: {text: "Heading"}, :class => 'govuk-input govuk-!-width-three-quarters'%>
 
@@ -12,24 +12,15 @@
                set its own id, and the GOVUKDesignSystemFormBuilder hijacks it -->
           <div class="govuk-form-group gem-c-govspeak">
 
-            <label id="content-list-hint" for="content-list-editor" class="govuk-label">
-              Table of contents
-            </label>
-
-            <% if @content_page_version&.errors[:content_list].count > 0 %>
-              <span class="govuk-error-message"><%= @content_page_version.errors[:content_list][0] %></span>
-            <% end %>
-            <% text_area_class_content_list = (@content_page_version.errors[:content_list].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
-
-            <%= form.text_area :content_list, id: 'content-list-editor', rows: 20, cols: 35, class: text_area_class_content_list %>
+            <%= form.govuk_text_area :content_list, id: 'content-list-editor', rows: 8, cols: 35, label: {text: "Table of contents"} %>
 
             <label id="markdown-hint" for="markdown-editor" class="govuk-label">
               Content
             </label>
-            <% if @content_page_version&.errors[:markdown].count > 0 %>
+            <% if @content_page_version&.errors[:markdown].present? %>
               <span class="govuk-error-message"><%= @content_page_version.errors[:markdown][0] %></span>
             <% end %>
-            <% text_area_class_markdown = (@content_page_version.errors[:markdown].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
+            <% text_area_class_markdown = (@content_page_version&.errors[:markdown].present?) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
 
             <%= form.text_area :markdown, :id => 'markdown-editor', :rows => 20, :cols => 35,  :class => text_area_class_markdown %>
             

--- a/app/views/admin/content_page_versions/_form.html.erb
+++ b/app/views/admin/content_page_versions/_form.html.erb
@@ -19,9 +19,9 @@
             <% if @content_page_version&.errors[:content_list].count > 0 %>
               <span class="govuk-error-message"><%= @content_page_version.errors[:content_list][0] %></span>
             <% end %>
-            <% text_area_class_2 = (@content_page_version.errors[:content_list].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
+            <% text_area_class_content_list = (@content_page_version.errors[:content_list].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
 
-            <%= form.text_area :content_list, id: 'content-list-editor', rows: 20, cols: 35, class: text_area_class_2 %>
+            <%= form.text_area :content_list, id: 'content-list-editor', rows: 20, cols: 35, class: text_area_class_content_list %>
 
             <label id="markdown-hint" for="markdown-editor" class="govuk-label">
               Content
@@ -29,9 +29,9 @@
             <% if @content_page_version&.errors[:markdown].count > 0 %>
               <span class="govuk-error-message"><%= @content_page_version.errors[:markdown][0] %></span>
             <% end %>
-            <% text_area_class = (@content_page_version.errors[:markdown].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
+            <% text_area_class_markdown = (@content_page_version.errors[:markdown].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
 
-            <%= form.text_area :markdown, :id => 'markdown-editor', :rows => 20, :cols => 35,  :class => text_area_class %>
+            <%= form.text_area :markdown, :id => 'markdown-editor', :rows => 20, :cols => 35,  :class => text_area_class_markdown %>
             
             <%= form.govuk_text_area :description, label: {text: "Meta Description"} %>
           </div>

--- a/app/views/admin/content_page_versions/_form.html.erb
+++ b/app/views/admin/content_page_versions/_form.html.erb
@@ -12,7 +12,7 @@
                set its own id, and the GOVUKDesignSystemFormBuilder hijacks it -->
           <div class="govuk-form-group gem-c-govspeak">
 
-            <%= form.govuk_text_area :content_list, id: 'content-list-editor', rows: 8, cols: 35, label: {text: "Table of contents"} %>
+            <%= form.text_area :content_list, id: 'content-list-editor', rows: 8, cols: 35, class: 'govuk-input govuk-textarea', label: {text: "Table of contents"} %>
 
             <label id="markdown-hint" for="markdown-editor" class="govuk-label">
               Content

--- a/app/views/admin/content_page_versions/_form.html.erb
+++ b/app/views/admin/content_page_versions/_form.html.erb
@@ -23,9 +23,6 @@
 
             <%= form.text_area :content_list, id: 'content-list-editor', rows: 20, cols: 35, class: text_area_class_2 %>
 
-
-
-
             <label id="markdown-hint" for="markdown-editor" class="govuk-label">
               Content
             </label>
@@ -35,8 +32,6 @@
             <% text_area_class = (@content_page_version.errors[:markdown].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
 
             <%= form.text_area :markdown, :id => 'markdown-editor', :rows => 20, :cols => 35,  :class => text_area_class %>
-            
-            
             
             <%= form.govuk_text_area :description, label: {text: "Meta Description"} %>
           </div>

--- a/app/views/admin/content_page_versions/_form.html.erb
+++ b/app/views/admin/content_page_versions/_form.html.erb
@@ -4,13 +4,28 @@
       <p class="govuk-heading-m">Details</p>
       <%= form_with(model: [:admin, :content_page, @content_page_version], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
         <fieldset class="govuk-fieldset">
-          <%= form.govuk_error_summary order: %i[title markdown]  %>
+          <%= form.govuk_error_summary order: %i[title markdown content_list]  %>
 
           <%= form.govuk_text_field :title, label: {text: "Heading"}, :class => 'govuk-input govuk-!-width-three-quarters'%>
 
           <!-- This text_area is not rendered with gov_text_field because it needs to
                set its own id, and the GOVUKDesignSystemFormBuilder hijacks it -->
           <div class="govuk-form-group gem-c-govspeak">
+
+            <label id="content-list-hint" for="content-list-editor" class="govuk-label">
+              Table of contents
+            </label>
+
+            <% if @content_page_version&.errors[:content_list].count > 0 %>
+              <span class="govuk-error-message"><%= @content_page_version.errors[:content_list][0] %></span>
+            <% end %>
+            <% text_area_class_2 = (@content_page_version.errors[:content_list].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
+
+            <%= form.text_area :content_list, id: 'content-list-editor', rows: 20, cols: 35, class: text_area_class_2 %>
+
+
+
+
             <label id="markdown-hint" for="markdown-editor" class="govuk-label">
               Content
             </label>
@@ -20,6 +35,9 @@
             <% text_area_class = (@content_page_version.errors[:markdown].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
 
             <%= form.text_area :markdown, :id => 'markdown-editor', :rows => 20, :cols => 35,  :class => text_area_class %>
+            
+            
+            
             <%= form.govuk_text_area :description, label: {text: "Meta Description"} %>
           </div>
 
@@ -36,6 +54,9 @@
 
     <div class="govuk-grid-column-one-half">
         <p class="govuk-heading-m">Preview</p>
+        <div id='content-list-render' class='gem-c-govspeak'>
+          <%= translate_markdown(@content_page_version.content_list) %>
+        </div>
         <div id='markdown-render' class='gem-c-govspeak'>
           <%= translate_markdown(@content_page_version.markdown) %>
         </div>

--- a/app/views/admin/content_page_versions/preview_of_draft.erb
+++ b/app/views/admin/content_page_versions/preview_of_draft.erb
@@ -5,6 +5,10 @@
 <h1 class="govuk-heading-l">
   <%= @content_page_version.title %>
 </h1>
+<%= translate_markdown(@content_page_version.content_list) %>
+<div class="gem-c-print-link govuk-!-margin-top-7 govuk-!-margin-bottom-2" id="print-button">
+  <button class="govuk-link gem-c-print-link__button" onclick="window.print()" data-module="print-link" >Print this page</button>
+</div>
 <%= translate_markdown(@content_page_version.markdown) %>
 
 <div class="fixed-footer">

--- a/app/views/admin/content_page_versions/preview_of_draft.erb
+++ b/app/views/admin/content_page_versions/preview_of_draft.erb
@@ -5,11 +5,18 @@
 <h1 class="govuk-heading-l">
   <%= @content_page_version.title %>
 </h1>
+<% if @page.content_list %>
+  <p class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
+<% end %>
 <%= translate_markdown(@content_page_version.content_list) %>
+<% if @content_page_version.content_list %>
 <div class="gem-c-print-link govuk-!-margin-top-7 govuk-!-margin-bottom-2" id="print-button">
   <button class="govuk-link gem-c-print-link__button" onclick="window.print()" data-module="print-link" >Print this page</button>
 </div>
-<%= translate_markdown(@content_page_version.markdown) %>
+<% end %>
+<div class="govuk-!-margin-top-4">
+  <%= translate_markdown(@content_page_version.markdown) %>
+</div>
 
 <div class="fixed-footer">
   <%= button_to "Publish", publish_admin_content_page_content_page_version_path(@content_page_version.content_page, @content_page_version), class: "govuk-button", data: { confirm: "Are you sure you want to publish this draft ?" } %>

--- a/app/views/admin/content_page_versions/preview_of_draft.erb
+++ b/app/views/admin/content_page_versions/preview_of_draft.erb
@@ -5,14 +5,12 @@
 <h1 class="govuk-heading-l">
   <%= @content_page_version.title %>
 </h1>
-<% if @page.content_list %>
-  <p class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
-<% end %>
-<%= translate_markdown(@content_page_version.content_list) %>
 <% if @content_page_version.content_list %>
-<div class="gem-c-print-link govuk-!-margin-top-7 govuk-!-margin-bottom-2" id="print-button">
-  <button class="govuk-link gem-c-print-link__button" onclick="window.print()" data-module="print-link" >Print this page</button>
-</div>
+  <p class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
+  <%= translate_markdown(@content_page_version.content_list) %>
+<% end %>
+<% if @content_page_version.content_list %>
+  <%= print_button("govuk-!-margin-top-7", "govuk-!-margin-bottom-2") %> 
 <% end %>
 <div class="govuk-!-margin-top-4">
   <%= translate_markdown(@content_page_version.markdown) %>

--- a/app/views/admin/content_page_versions/preview_of_draft.erb
+++ b/app/views/admin/content_page_versions/preview_of_draft.erb
@@ -6,7 +6,7 @@
   <%= @content_page_version.title %>
 </h1>
 <% if @content_page_version.content_list %>
-  <p class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
+  <p id="contents-list-heading" class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
   <%= translate_markdown(@content_page_version.content_list) %>
 <% end %>
 <% if @content_page_version.content_list %>

--- a/app/views/admin/content_pages/_form.html.erb
+++ b/app/views/admin/content_pages/_form.html.erb
@@ -52,7 +52,7 @@
         <div id='content-list-render' class='gem-c-govspeak'>
           <%= translate_markdown(content_page.content_list) %>
         </div>
-        <div id='markdown-render' class='gem-c-govspeak'>
+        <div id='markdown-render' class='gem-c-govspeak govuk-!-margin-top-5'>
           <%= translate_markdown(content_page.markdown) %>
         </div>
     </div>

--- a/app/views/admin/content_pages/_form.html.erb
+++ b/app/views/admin/content_pages/_form.html.erb
@@ -12,8 +12,6 @@
         <% markdown_class = 'govuk-form-group--error' if content_page.errors[:markdown].count > 0 || content_page.errors[:content_list].count > 0 %>
         <div class="govuk-form-group gem-c-govspeak govuk-form-group <%= markdown_class %>" id="content-block-markdown-field-error">
 
-
-
           <label id="content-list-hint" for="content-list-editor" class="govuk-label">
             Table of contents
           </label>
@@ -25,10 +23,6 @@
 
           <%= form.text_area :content_list, id: 'content-list-editor', rows: 20, cols: 35, class: text_area_class_2 %>
           
-
-
-
-
           <label id="markdown-hint" for="markdown-editor" class="govuk-label">
             Content - Markdown for the page
           </label>
@@ -40,11 +34,7 @@
 
           <%= form.text_area :markdown, id: 'markdown-editor', rows: 20, cols: 35, class: text_area_class %>
 
-
-
-
           <%= form.hidden_field :parent_id, id: "parent_id" %>
-
           <%= form.govuk_text_field :position, label: {text: "Position"}%>
           <%= form.govuk_text_area :description, label: {text: "Meta Description"} %>
         </div>

--- a/app/views/admin/content_pages/_form.html.erb
+++ b/app/views/admin/content_pages/_form.html.erb
@@ -3,34 +3,26 @@
     <div class="govuk-grid-column-one-half">
       <p class="govuk-heading-m">Details</p>
       <%= form_with(model: [:admin, content_page], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
-        <%= form.govuk_error_summary order: %i[title markdown content_list position]  %>
+        <%= form.govuk_error_summary order: %i[title markdown position]  %>
 
         <%= form.govuk_text_field :title, label: {text: "Heading"}, :class => 'govuk-input govuk-!-width-three-quarters', :disabled => (@content_page.title && !@content_page.parent_id)%>
 
         <!-- This text_area is not rendered with gov_text_field because it needs to
              set its own id, and the GOVUKDesignSystemFormBuilder hijacks it -->
-        <% markdown_class = 'govuk-form-group--error' if content_page.errors[:markdown].count > 0 || content_page.errors[:content_list].count > 0 %>
+        <% markdown_class = 'govuk-form-group--error' if @content_page&.errors[:markdown].present? %> 
+        
         <div class="govuk-form-group gem-c-govspeak govuk-form-group <%= markdown_class %>" id="content-block-markdown-field-error">
 
-          <label id="content-list-hint" for="content-list-editor" class="govuk-label">
-            Table of contents
-          </label>
-
-          <% if content_page&.errors[:content_list].count > 0 %>
-            <span class="govuk-error-message"><%= content_page.errors[:content_list][0] %></span>
-          <% end %>
-          <% text_area_class_content_list = (content_page.errors[:content_list].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
-
-          <%= form.text_area :content_list, id: 'content-list-editor', class: text_area_class_content_list %>
+          <%= form.govuk_text_area :content_list, id: 'content-list-editor', rows: 8, cols: 35, label: {text: "Table of contents"} %>
           
           <label id="markdown-hint" for="markdown-editor" class="govuk-label">
             Content - Markdown for the page
           </label>
 
-          <% if content_page&.errors[:markdown].count > 0 %>
+          <% if @content_page&.errors[:markdown].present? %>
             <span class="govuk-error-message"><%= content_page.errors[:markdown][0] %></span>
           <% end %>
-          <% text_area_class_markdown = (content_page.errors[:markdown].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
+          <% text_area_class_markdown = (content_page.errors[:markdown].present? ) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
 
           <%= form.text_area :markdown, id: 'markdown-editor', class: text_area_class_markdown %>
 

--- a/app/views/admin/content_pages/_form.html.erb
+++ b/app/views/admin/content_pages/_form.html.erb
@@ -3,23 +3,46 @@
     <div class="govuk-grid-column-one-half">
       <p class="govuk-heading-m">Details</p>
       <%= form_with(model: [:admin, content_page], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder) do |form| %>
-        <%= form.govuk_error_summary order: %i[title markdown position]  %>
+        <%= form.govuk_error_summary order: %i[title markdown content_list position]  %>
 
         <%= form.govuk_text_field :title, label: {text: "Heading"}, :class => 'govuk-input govuk-!-width-three-quarters', :disabled => (@content_page.title && !@content_page.parent_id)%>
 
         <!-- This text_area is not rendered with gov_text_field because it needs to
              set its own id, and the GOVUKDesignSystemFormBuilder hijacks it -->
-        <% markdown_class = 'govuk-form-group--error' if content_page.errors[:markdown].count > 0 %>
+        <% markdown_class = 'govuk-form-group--error' if content_page.errors[:markdown].count > 0 || content_page.errors[:content_list].count > 0 %>
         <div class="govuk-form-group gem-c-govspeak govuk-form-group <%= markdown_class %>" id="content-block-markdown-field-error">
+
+
+
+          <label id="content-list-hint" for="content-list-editor" class="govuk-label">
+            Table of contents
+          </label>
+
+          <% if content_page&.errors[:content_list].count > 0 %>
+            <span class="govuk-error-message"><%= content_page.errors[:content_list][0] %></span>
+          <% end %>
+          <% text_area_class_2 = (content_page.errors[:content_list].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
+
+          <%= form.text_area :content_list, id: 'content-list-editor', rows: 20, cols: 35, class: text_area_class_2 %>
+          
+
+
+
+
           <label id="markdown-hint" for="markdown-editor" class="govuk-label">
             Content - Markdown for the page
           </label>
+
           <% if content_page&.errors[:markdown].count > 0 %>
             <span class="govuk-error-message"><%= content_page.errors[:markdown][0] %></span>
           <% end %>
           <% text_area_class = (content_page.errors[:markdown].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
 
           <%= form.text_area :markdown, id: 'markdown-editor', rows: 20, cols: 35, class: text_area_class %>
+
+
+
+
           <%= form.hidden_field :parent_id, id: "parent_id" %>
 
           <%= form.govuk_text_field :position, label: {text: "Position"}%>
@@ -36,6 +59,9 @@
 
     <div class="govuk-grid-column-one-half">
         <p class="govuk-heading-m">Preview</p>
+        <div id='content-list-render' class='gem-c-govspeak'>
+          <%= translate_markdown(content_page.content_list) %>
+        </div>
         <div id='markdown-render' class='gem-c-govspeak'>
           <%= translate_markdown(content_page.markdown) %>
         </div>

--- a/app/views/admin/content_pages/_form.html.erb
+++ b/app/views/admin/content_pages/_form.html.erb
@@ -19,9 +19,9 @@
           <% if content_page&.errors[:content_list].count > 0 %>
             <span class="govuk-error-message"><%= content_page.errors[:content_list][0] %></span>
           <% end %>
-          <% text_area_class_2 = (content_page.errors[:content_list].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
+          <% text_area_class_content_list = (content_page.errors[:content_list].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
 
-          <%= form.text_area :content_list, id: 'content-list-editor', rows: 20, cols: 35, class: text_area_class_2 %>
+          <%= form.text_area :content_list, id: 'content-list-editor', class: text_area_class_content_list %>
           
           <label id="markdown-hint" for="markdown-editor" class="govuk-label">
             Content - Markdown for the page
@@ -30,9 +30,9 @@
           <% if content_page&.errors[:markdown].count > 0 %>
             <span class="govuk-error-message"><%= content_page.errors[:markdown][0] %></span>
           <% end %>
-          <% text_area_class = (content_page.errors[:markdown].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
+          <% text_area_class_markdown = (content_page.errors[:markdown].count > 0) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
 
-          <%= form.text_area :markdown, id: 'markdown-editor', rows: 20, cols: 35, class: text_area_class %>
+          <%= form.text_area :markdown, id: 'markdown-editor', class: text_area_class_markdown %>
 
           <%= form.hidden_field :parent_id, id: "parent_id" %>
           <%= form.govuk_text_field :position, label: {text: "Position"}%>

--- a/app/views/admin/content_pages/_form.html.erb
+++ b/app/views/admin/content_pages/_form.html.erb
@@ -13,7 +13,10 @@
         
         <div class="govuk-form-group gem-c-govspeak govuk-form-group <%= markdown_class %>" id="content-block-markdown-field-error">
 
-          <%= form.text_area :content_list, id: 'content-list-editor', rows: 8, cols: 35, class: 'govuk-input govuk-textarea',  label: {text: "Table of contents"} %>
+          <label id="content-list-hint" for="content-list-editor" class="govuk-label">
+            Table of contents
+          </label>
+          <%= form.text_area :content_list, id: 'content-list-editor', rows: 8, cols: 35, class: 'govuk-input govuk-textarea' %>
           
           <label id="markdown-hint" for="markdown-editor" class="govuk-label">
             Content - Markdown for the page
@@ -22,9 +25,8 @@
           <% if @content_page&.errors[:markdown].present? %>
             <span class="govuk-error-message"><%= content_page.errors[:markdown][0] %></span>
           <% end %>
-          <% text_area_class_markdown = (content_page.errors[:markdown].present? ) ? 'govuk-input govuk-input--error govuk-textarea' : 'govuk-input govuk-textarea' %>
 
-          <%= form.text_area :markdown, id: 'markdown-editor', class: text_area_class_markdown %>
+          <%= form.text_area :markdown, id: 'markdown-editor', class: govuk_input_classes(:textarea, errors: @content_page.errors[:markdown]) %>
 
           <%= form.hidden_field :parent_id, id: "parent_id" %>
           <%= form.govuk_text_field :position, label: {text: "Position"}%>

--- a/app/views/admin/content_pages/_form.html.erb
+++ b/app/views/admin/content_pages/_form.html.erb
@@ -13,7 +13,7 @@
         
         <div class="govuk-form-group gem-c-govspeak govuk-form-group <%= markdown_class %>" id="content-block-markdown-field-error">
 
-          <%= form.govuk_text_area :content_list, id: 'content-list-editor', rows: 8, cols: 35, label: {text: "Table of contents"} %>
+          <%= form.text_area :content_list, id: 'content-list-editor', rows: 8, cols: 35, class: 'govuk-input govuk-textarea',  label: {text: "Table of contents"} %>
           
           <label id="markdown-hint" for="markdown-editor" class="govuk-label">
             Content - Markdown for the page

--- a/app/views/admin/content_pages/preview_of_live.erb
+++ b/app/views/admin/content_pages/preview_of_live.erb
@@ -6,13 +6,11 @@
   <%= @content_page.title %>
 </h1>
 <% if @content_page.content_list %>
-<p class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
+  <p class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
+  <%= translate_markdown(@content_page.content_list) %>
 <% end %>
-<%= translate_markdown(@content_page.content_list) %>
 <% if @content_page.content_list %>
-<div class="gem-c-print-link govuk-!-margin-top-7" id="print-button">
-  <button class="govuk-link gem-c-print-link__button" onclick="window.print()" data-module="print-link" >Print this page</button>
-</div>
+  <%= print_button("govuk-!-margin-top-7") %>
 <% end %>
 <div class="govuk-!-margin-top-4">
   <%= translate_markdown(@content_page.markdown) %>

--- a/app/views/admin/content_pages/preview_of_live.erb
+++ b/app/views/admin/content_pages/preview_of_live.erb
@@ -5,12 +5,18 @@
 <h1 class="govuk-heading-l">
   <%= @content_page.title %>
 </h1>
+<% if @content_page.content_list %>
+<p class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
+<% end %>
 <%= translate_markdown(@content_page.content_list) %>
+<% if @content_page.content_list %>
 <div class="gem-c-print-link govuk-!-margin-top-7" id="print-button">
   <button class="govuk-link gem-c-print-link__button" onclick="window.print()" data-module="print-link" >Print this page</button>
 </div>
-<%= translate_markdown(@content_page.markdown) %>
-
+<% end %>
+<div class="govuk-!-margin-top-4">
+  <%= translate_markdown(@content_page.markdown) %>
+</div>
 <div class="fixed-footer">
   <%= link_to 'Back',  versions_admin_content_page_path(@content_page) %>
 </div>

--- a/app/views/admin/content_pages/preview_of_live.erb
+++ b/app/views/admin/content_pages/preview_of_live.erb
@@ -6,7 +6,7 @@
   <%= @content_page.title %>
 </h1>
 <% if @content_page.content_list %>
-  <p class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
+  <p id="contents-list-heading" class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
   <%= translate_markdown(@content_page.content_list) %>
 <% end %>
 <% if @content_page.content_list %>

--- a/app/views/admin/content_pages/preview_of_live.erb
+++ b/app/views/admin/content_pages/preview_of_live.erb
@@ -5,6 +5,10 @@
 <h1 class="govuk-heading-l">
   <%= @content_page.title %>
 </h1>
+<%= translate_markdown(@content_page.content_list) %>
+<div class="gem-c-print-link govuk-!-margin-top-7" id="print-button">
+  <button class="govuk-link gem-c-print-link__button" onclick="window.print()" data-module="print-link" >Print this page</button>
+</div>
 <%= translate_markdown(@content_page.markdown) %>
 
 <div class="fixed-footer">

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -4,4 +4,8 @@
 <h1 class="govuk-heading-l">
   <%= @page.title %>
 </h1>
+<%= translate_markdown(@page.content_list) %>
+<div class="gem-c-print-link govuk-!-margin-top-7" id="print-button">
+  <button class="govuk-link gem-c-print-link__button" onclick="window.print()" data-module="print-link" >Print this page</button>
+</div>
 <%= translate_markdown(@page.markdown) %>

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -6,12 +6,10 @@
 </h1>
 <% if @page.content_list %>
   <p class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
+  <%= translate_markdown(@page.content_list) %>
 <% end %>
-<%= translate_markdown(@page.content_list) %>
 <% if @page.content_list %>
-<div class="gem-c-print-link govuk-!-margin-top-7" id="print-button">
-  <button class="govuk-link gem-c-print-link__button" onclick="window.print()" data-module="print-link" >Print this page</button>
-</div>
+  <%= print_button("govuk-!-margin-top-7") %>
 <% end %>
 <div class="govuk-!-margin-top-4">
   <%= translate_markdown(@page.markdown) %>

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -5,7 +5,7 @@
   <%= @page.title %>
 </h1>
 <% if @page.content_list %>
-  <p class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
+  <p id="contents-list-heading" class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
   <%= translate_markdown(@page.content_list) %>
 <% end %>
 <% if @page.content_list %>

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -4,8 +4,15 @@
 <h1 class="govuk-heading-l">
   <%= @page.title %>
 </h1>
+<% if @page.content_list %>
+  <p class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
+<% end %>
 <%= translate_markdown(@page.content_list) %>
+<% if @page.content_list %>
 <div class="gem-c-print-link govuk-!-margin-top-7" id="print-button">
   <button class="govuk-link gem-c-print-link__button" onclick="window.print()" data-module="print-link" >Print this page</button>
 </div>
-<%= translate_markdown(@page.markdown) %>
+<% end %>
+<div class="govuk-!-margin-top-4">
+  <%= translate_markdown(@page.markdown) %>
+</div>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -16,6 +16,10 @@ $(document).ready(function() {
     NodeList.prototype.forEach = Array.prototype.forEach;
   };
 
+  $('#content-list-editor').keyup(function() {
+    createPreview('#content-list-editor','#content-list-render');
+  });
+
   $('#markdown-editor').keyup(function() {
     createPreview('#markdown-editor','#markdown-render');
   });

--- a/app/webpacker/styles/_cms.scss
+++ b/app/webpacker/styles/_cms.scss
@@ -26,6 +26,10 @@
   height: 350px;
 }
 
+#content-list-editor {
+  height: 150px;
+}
+
 .copy-to-clipboard {
   margin-bottom: 20px;
   background: #f3f2f1;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,8 +108,6 @@ en:
               blank: Heading must not be blank
             markdown:
               blank: Content must not be blank
-            content_list:
-              blank: Content list must not be blank
             position:
               blank: Position must not be blank
               taken: Position is already taken
@@ -122,8 +120,6 @@ en:
               format: "Heading should only contain alphabetic, numeric and -#{ContentPage::CHARS_TO_OMIT_FROM_SLUG}"
             markdown:
               blank: Content must not be blank
-            content_list:
-              blank: Content list must not be blank
         content_asset:
           attributes:
             title:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,8 @@ en:
               blank: Heading must not be blank
             markdown:
               blank: Content must not be blank
+            content_list:
+              blank: Content list must not be blank
             position:
               blank: Position must not be blank
               taken: Position is already taken
@@ -120,6 +122,8 @@ en:
               format: "Heading should only contain alphabetic, numeric and -#{ContentPage::CHARS_TO_OMIT_FROM_SLUG}"
             markdown:
               blank: Content must not be blank
+            content_list:
+              blank: Content list must not be blank
         content_asset:
           attributes:
             title:

--- a/db/migrate/20220203120504_add_content_list_to_content_pages.rb
+++ b/db/migrate/20220203120504_add_content_list_to_content_pages.rb
@@ -1,0 +1,5 @@
+class AddContentListToContentPages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :content_pages, :content_list, :string
+  end
+end

--- a/db/migrate/20220203120522_add_content_list_to_content_page_versions.rb
+++ b/db/migrate/20220203120522_add_content_list_to_content_page_versions.rb
@@ -1,0 +1,5 @@
+class AddContentListToContentPageVersions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :content_page_versions, :content_list, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_01_161815) do
+ActiveRecord::Schema.define(version: 2022_02_03_120522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 2022_02_01_161815) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "author"
     t.string "description"
+    t.string "content_list"
     t.index ["content_page_id"], name: "index_content_page_versions_on_content_page_id"
   end
 
@@ -128,6 +129,7 @@ ActiveRecord::Schema.define(version: 2022_02_01_161815) do
     t.boolean "is_published", default: false
     t.string "author"
     t.string "description"
+    t.string "content_list"
     t.index ["position", "parent_id"], name: "index_content_pages_on_position_and_parent_id", unique: true
     t.index ["title"], name: "index_content_pages_on_title", unique: true
   end

--- a/spec/factories/content_page_versions.rb
+++ b/spec/factories/content_page_versions.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :content_page_version do
     content_page # Note that another content page version will be created on creating this content page
     title { Faker::Commerce.product_name }
+    content_list { Faker::Lorem.paragraph }
     markdown { Faker::Lorem.paragraph }
     author { Faker::Name.name }
     description { Faker::Lorem.paragraph }

--- a/spec/factories/content_page_versions.rb
+++ b/spec/factories/content_page_versions.rb
@@ -7,4 +7,8 @@ FactoryBot.define do
     author { Faker::Name.name }
     description { Faker::Lorem.paragraph }
   end
+
+  trait :content_list_empty do
+    content_list { nil }
+  end
 end

--- a/spec/factories/content_pages.rb
+++ b/spec/factories/content_pages.rb
@@ -9,6 +9,7 @@ end
 FactoryBot.define do
   factory :content_page do
     title { sentence_without_puncutation }
+    content_list { Faker::Lorem.paragraph }
     markdown { "# Fake title - #{Faker::Lorem.word}" }
     parent_id { nil }
     position { ContentPage.maximum("position").nil? ? 1 : ContentPage.maximum("position") + 1 }

--- a/spec/factories/content_pages.rb
+++ b/spec/factories/content_pages.rb
@@ -51,4 +51,8 @@ FactoryBot.define do
   trait :invalid_title do
     title { "Invalid!" }
   end
+
+  trait :content_list_nil do
+    content_list { nil }
+  end
 end

--- a/spec/features/content_page_versions_spec.rb
+++ b/spec/features/content_page_versions_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.feature "View pages", type: :feature do
   given(:parent_page) { FactoryBot.create(:content_page, :published, :top_level) }
-  given(:content_page_version) { FactoryBot.create(:content_page_version ) }
+  given(:content_page_version) { FactoryBot.create(:content_page_version) }
 
   scenario "Navigate to a preview of draft page and check that 2 print buttons are rendered on the page" do
     sign_in FactoryBot.create(:user)
     visit "/admin/pages/#{parent_page.id}/content_page_versions/#{content_page_version.id}/preview_of_draft"
-    page.find('p', text: 'Contents', id: 'contents-list-heading')
+    page.find("p", text: "Contents", id: "contents-list-heading")
 
-    expect(page.body).to have_button('Print this page').twice
+    expect(page.body).to have_button("Print this page").twice
   end
 
   scenario "Navigate to a preview of draft page and check that 1 print button is on the page" do
@@ -17,6 +17,6 @@ RSpec.feature "View pages", type: :feature do
     sign_in FactoryBot.create(:user)
     visit "/admin/pages/#{parent_page.id}/content_page_versions/#{page_version.id}/preview_of_draft"
 
-    expect(page.body).to have_button('Print this page').once
+    expect(page.body).to have_button("Print this page").once
   end
 end

--- a/spec/features/content_page_versions_spec.rb
+++ b/spec/features/content_page_versions_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.feature "View pages", type: :feature do
+  given(:parent_page) { FactoryBot.create(:content_page, :published, :top_level) }
+  given(:content_page_version) { FactoryBot.create(:content_page_version ) }
+
+  scenario "Navigate to a preview of draft page and check that 2 print buttons are rendered on the page" do
+    sign_in FactoryBot.create(:user)
+    visit "/admin/pages/#{parent_page.id}/content_page_versions/#{content_page_version.id}/preview_of_draft"
+    page.find('p', text: 'Contents', id: 'contents-list-heading')
+
+    expect(page.body).to have_button('Print this page').twice
+  end
+
+  scenario "Navigate to a preview of draft page and check that 1 print button is on the page" do
+    page_version = FactoryBot.create(:content_page_version, :content_list_empty)
+    sign_in FactoryBot.create(:user)
+    visit "/admin/pages/#{parent_page.id}/content_page_versions/#{page_version.id}/preview_of_draft"
+
+    expect(page.body).to have_button('Print this page').once
+  end
+end

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.feature "View pages", type: :feature do
   given(:parent_page) { FactoryBot.create(:content_page, :published, :top_level) }
   given(:child_page) { FactoryBot.create(:content_page, :published, parent_id: parent_page.id) }
+  given(:content_page_version) { FactoryBot.create(:content_page_version ) }
 
   scenario "Navigate to Content Pages" do
     sign_in FactoryBot.create(:user)
@@ -37,15 +38,6 @@ RSpec.feature "View pages", type: :feature do
     visit "/admin/pages/#{parent_page.id}/edit"
 
     expect(page).to be_axe_clean
-  end
-
-  # TODO
-  scenario "Navigate to a preview of live page and check that a print button is rendered after the content list" do
-    sign_in FactoryBot.create(:user)
-    visit "admin/pages/#{child_page.id}/preview_of_live"
-    page.find('ul', class: 'contents-list__list')
-
-    expect(page).to have_button('Print this page')
   end
 
   scenario "A user with the role of editor should be able to edit pages in the CMS" do
@@ -119,5 +111,21 @@ RSpec.feature "View pages", type: :feature do
     page.click_button("Save")
 
     expect(page.body).to include("You don't have permission to create pages")
+  end
+
+  scenario "Navigate to a preview of live page and check that 2 print buttons are rendered on the page" do
+    sign_in FactoryBot.create(:user)
+    visit "/admin/pages/#{child_page.id}/preview_of_live"
+    page.find('p', text: 'Contents', id: 'contents-list-heading')
+
+    expect(page.body).to have_button('Print this page').twice
+  end
+
+  scenario "Navigate to a preview of live page and check that 1 print button is on the page" do
+    content_page = FactoryBot.create(:content_page, :published, :top_level, :content_list_nil)
+    sign_in FactoryBot.create(:user)
+    visit "/admin/pages/#{content_page.id}/preview_of_live"
+
+    expect(page.body).to have_button('Print this page').once
   end
 end

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -39,6 +39,15 @@ RSpec.feature "View pages", type: :feature do
     expect(page).to be_axe_clean
   end
 
+  # TODO
+  scenario "Navigate to a preview of live page and check that a print button is rendered after the content list" do
+    sign_in FactoryBot.create(:user)
+    visit "admin/pages/#{child_page.id}/preview_of_live"
+    page.find('ul', class: 'contents-list__list')
+
+    expect(page).to have_button('Print this page')
+  end
+
   scenario "A user with the role of editor should be able to edit pages in the CMS" do
     sign_in FactoryBot.create(:user, :editor)
 

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "View pages", type: :feature do
   given(:parent_page) { FactoryBot.create(:content_page, :published, :top_level) }
   given(:child_page) { FactoryBot.create(:content_page, :published, parent_id: parent_page.id) }
-  given(:content_page_version) { FactoryBot.create(:content_page_version ) }
+  given(:content_page_version) { FactoryBot.create(:content_page_version) }
 
   scenario "Navigate to Content Pages" do
     sign_in FactoryBot.create(:user)
@@ -116,9 +116,9 @@ RSpec.feature "View pages", type: :feature do
   scenario "Navigate to a preview of live page and check that 2 print buttons are rendered on the page" do
     sign_in FactoryBot.create(:user)
     visit "/admin/pages/#{child_page.id}/preview_of_live"
-    page.find('p', text: 'Contents', id: 'contents-list-heading')
+    page.find("p", text: "Contents", id: "contents-list-heading")
 
-    expect(page.body).to have_button('Print this page').twice
+    expect(page.body).to have_button("Print this page").twice
   end
 
   scenario "Navigate to a preview of live page and check that 1 print button is on the page" do
@@ -126,6 +126,6 @@ RSpec.feature "View pages", type: :feature do
     sign_in FactoryBot.create(:user)
     visit "/admin/pages/#{content_page.id}/preview_of_live"
 
-    expect(page.body).to have_button('Print this page').once
+    expect(page.body).to have_button("Print this page").once
   end
 end

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -74,6 +74,7 @@ RSpec.feature "View pages", type: :feature do
       visit "/admin/pages/new?parent_id=#{parent_page.id}"
 
       page.find_field("content_page[title]").set(attributes[:title])
+      page.find_field("content_page[content_list]").set(attributes[:content_list])
       page.find_field("content_page[markdown]").set(attributes[:markdown])
       page.find_field("content_page[position]").set(rand(10_000))
       page.find_field("content_page[description]").set(attributes[:description])
@@ -83,6 +84,7 @@ RSpec.feature "View pages", type: :feature do
       saved_page = ContentPage.find_by_title attributes[:title]
 
       expect(saved_page.markdown).to eq(attributes[:markdown])
+      expect(saved_page.content_list).to eq(attributes[:content_list])
       expect(saved_page.description).to eq(attributes[:description])
     end
   end
@@ -102,6 +104,7 @@ RSpec.feature "View pages", type: :feature do
     visit "/admin/pages/new?parent_id=#{child_page.id}"
 
     page.find_field("content_page[title]").set(attributes[:title])
+    page.find_field("content_page[content_list]").set(attributes[:content_list])
     page.find_field("content_page[markdown]").set(attributes[:markdown])
     page.find_field("content_page[position]").set(rand(10_000))
     page.click_button("Save")

--- a/spec/features/drafting_and_publishing_spec.rb
+++ b/spec/features/drafting_and_publishing_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature "Drafting and publishing pages", type: :feature do
       visit "/admin/pages/new?parent_id=#{parent_page.id}"
 
       page.find_field("content_page[title]").set(attributes[:title])
+      page.find_field("content_page[content_list]").set(attributes[:content_list])
       page.find_field("content_page[markdown]").set(attributes[:markdown])
       page.find_field("content_page[position]").set(rand(10_000))
 

--- a/spec/requests/admin/content_page_versions_spec.rb
+++ b/spec/requests/admin/content_page_versions_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe Admin::ContentPageVersionsController, type: :request do
     it "updates the content page with data from content page version" do
       original_title = content_page.title
       expect { subject }.to(change { content_page.reload.title }.from(original_title).to(content_page_version.title))
+      expect(content_page.reload.content_list).to eq(content_page_version.content_list)
       expect(content_page.reload.markdown).to eq(content_page_version.markdown)
       expect(content_page.reload.description).to eq(content_page_version.description)
     end

--- a/spec/requests/admin/content_pages_spec.rb
+++ b/spec/requests/admin/content_pages_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Admin::ContentPagesController, type: :request do
         subject
         content_page = ContentPage.last
         expect(content_page.title).to eq(valid_attributes[:title])
+        expect(content_page.content_list).to eq(valid_attributes[:content_list])
         expect(content_page.markdown).to eq(valid_attributes[:markdown])
         expect(content_page.description).to eq(valid_attributes[:description])
       end
@@ -79,6 +80,7 @@ RSpec.describe Admin::ContentPagesController, type: :request do
         subject
         content_page_version = ContentPageVersion.last
         expect(content_page_version.title).to eq(valid_attributes[:title])
+        expect(content_page_version.content_list).to eq(valid_attributes[:content_list])
         expect(content_page_version.markdown).to eq(valid_attributes[:markdown])
         expect(content_page_version.description).to eq(valid_attributes[:description])
       end
@@ -132,6 +134,7 @@ RSpec.describe Admin::ContentPagesController, type: :request do
         patch admin_content_page_path(content_page), params: params
         content_page_version = content_page.content_page_versions.last
         expect(content_page_version.title).to eq(valid_attributes[:title])
+        expect(content_page_version.content_list).to eq(valid_attributes[:content_list])
         expect(content_page_version.description).to eq(valid_attributes[:description])
         expect(content_page_version.markdown).to eq(valid_attributes[:markdown])
         expect(content_page_version.author).to eq(editor.name)


### PR DESCRIPTION
## Ticket and context

Ticket: [HFEYP-617](https://dfedigital.atlassian.net/browse/HFEYP-617)
## Tech review
- Added a content list field to content pages (& versions) that allows an optional table of contents to be added to a content page
- An additional print button is placed between the table of contents (if present) and main markdown for the content page


### Code quality checks
- [ ] All commit messages are meaningful and true

## Product review
Testing of content page and content page versions
- Create or edit a content page and add some content to the fields and check the previews
- Edit a version and check its previews (Drafts and Live previews)


### How can someone see it in review app?
Added a content list to Communications&Language -> Interactions
https://eyfs-cms-review-pr-591.london.cloudapps.digital/communication-and-language/interactions

(Sign in to view the below link to edit/preview the content page)
https://eyfs-cms-review-pr-591.london.cloudapps.digital/admin/pages/2/versions