### PR TITLE
HFEYP-658 Articles featured image cropping

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,14 +13,10 @@ module ApplicationHelper
 
   def feature_image(page:)
     if page.featured_image.attached?
-      tag.div(class: "page-img-container") do
-        image_tag(url_for(page.featured_image), class: "page-responsive-img", alt: page.featured_alt_text, title: page.featured_alt_text, width: "500px")
-      end
+      image_tag(url_for(page.featured_image), class: "page-responsive-img", alt: page.featured_alt_text, title: page.featured_alt_text, width: "500px")
     else
-      tag.div(class: "page-img-container") do
-        image_text = page.featured_alt_text || "featured image alt text missing"
-        image_tag("apple.jpeg", class: "page-responsive-img", alt: image_text, title: image_text)
-      end
+      image_text = page.featured_alt_text || "featured image alt text missing"
+      image_tag("apple.jpeg", class: "page-responsive-img", alt: image_text, title: image_text)
     end
   end
 

--- a/app/webpacker/styles/layout-eyfs/landing-page.scss
+++ b/app/webpacker/styles/layout-eyfs/landing-page.scss
@@ -27,15 +27,8 @@
   box-shadow: 0 -1px 0px 0 rgba(0,0,0,0.2);
 }
 
-.page-img-container{
-  max-height: 360px;
-}
-
 .page-responsive-img{
-  width: 960px;
-  max-width: 100%;
-  max-height: 360px;
-  object-fit: cover;
+  width: 100%;
 }
 
 //styles for the card component


### PR DESCRIPTION
remove unnecessary page-img-container div and associated scss, remove all cropping of image so full height and width displayed

## Ticket and context

Ticket: [HFEYP-658](https://dfedigital.atlassian.net/browse/HFEYP-658)
## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true

## Product review

### How can someone see it in review app?
1. Click [the link to review app](https://eyfs-cms-review-pr-592.london.cloudapps.digital/articles/test) of an example article page
2. Verify that the featured image on an article is the full width of the container and shows the full height of the image. There should be no cropping.
3. Verify that the image is responsive and displays correctly for each page dimensions
4. Click [this link to view the preview page](https://eyfs-cms-review-pr-592.london.cloudapps.digital/admin/articles/test) of an article page 
5. Verify that this image also displays correctly.