### PR TITLE
HFEYP-657 Update user banner on save

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -36,7 +36,7 @@ module Admin
 
       if user_params[:password].blank?
         if @user.update_without_password(user_params)
-          redirect_to admin_users_path, notice: "User #{@user.name} updated"
+          redirect_to admin_users_path, notice: "User #{@user.name} saved"
         else
           render :edit
         end
@@ -44,7 +44,7 @@ module Admin
         @user.reset_password_token = Devise.friendly_token
         @user.reset_password(user_params[:password], user_params[:password_confirmation])
         if @user.reload.update_without_password(user_params)
-          redirect_to admin_users_path, notice: "User #{@user.name} updated and password changed"
+          redirect_to admin_users_path, notice: "User #{@user.name} saved and password changed"
         else
           render :edit
         end


### PR DESCRIPTION
## Ticket and context

When pressing save, wording is changed to say ‘user [username] saved’. This wording better reflects scenario when no changes are made, but the save button is pressed.

Ticket: [HFEYP-488](https://dfedigital.atlassian.net/browse/HFEYP-488)
## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true

## Product review

### How can someone see it in review app?
1. Click the link to[ admin page on review app](https://eyfs-cms-review-pr-594.london.cloudapps.digital/admin)
2. Choose a user to edit, and then press save. Verify that the message now displays ‘user [username] saved’
3. Edit a users password and then press save. Verify that this now says "User [username] saved and password changed"