### PR TITLE
Hfeyp 221 navigation first page and last pages dont loop

### DIFF
--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -55,11 +55,11 @@ class ContentPage < ApplicationRecord
   end
 
   def next_page
-    if next_id then ContentPage.find next_id end
+    ContentPage.find(next_id) if next_id
   end
 
   def previous_page
-    if previous_id then ContentPage.find previous_id end
+    ContentPage.find(previous_id) if previous_id
   end
 
   def navigation

--- a/app/models/content_page.rb
+++ b/app/models/content_page.rb
@@ -55,11 +55,11 @@ class ContentPage < ApplicationRecord
   end
 
   def next_page
-    ContentPage.find next_id
+    if next_id then ContentPage.find next_id end
   end
 
   def previous_page
-    ContentPage.find previous_id
+    if previous_id then ContentPage.find previous_id end
   end
 
   def navigation
@@ -87,18 +87,8 @@ class ContentPage < ApplicationRecord
       end
 
       page_order.each_with_index do |page, index|
-        page.next_id = if page == page_order.last
-                         page_order.first.id
-                       else
-                         page_order[index + 1].id
-                       end
-
-        page.previous_id = if page == page_order.first
-                             page_order.last.id
-                           else
-                             page_order[index - 1].id
-                           end
-
+        page.next_id = page_order[index + 1].id unless page == page_order.last
+        page.previous_id = page_order[index - 1].id unless page == page_order.first
         page.save!
       end
     end

--- a/spec/models/content_page_spec.rb
+++ b/spec/models/content_page_spec.rb
@@ -98,16 +98,14 @@ RSpec.describe ContentPage, type: :model do
         expect(@child2_of_top_level1.next_page.full_path).to eq "/tl2"
       end
 
-      it "The next_page should return the first page when called with the last page (loop around)" do
-        expect(@child2_of_top_level2.next_page).to eq(@top_level1)
-        expect(@child2_of_top_level2.next_page.full_path).to eq "/tl1"
+      it "There should be no next_page when on the last page" do
+        expect(@child2_of_top_level2.next_page).to eq(nil)
       end
     end
 
     context "Navigating to the Previous page" do
-      it "The previous_page should return the last child of the second parent when called on a first parent" do
-        expect(@top_level1.previous_page).to eq(@child2_of_top_level2)
-        expect(@top_level1.previous_page.full_path).to eq "/tl2/c2tl2"
+      it "There should be no previous_page when on the first page" do
+        expect(@top_level1.previous_page).to eq(nil)
       end
 
       it "The previous_page should return the previous sibling of a child if a sibling exists" do


### PR DESCRIPTION
## Ticket and context

Ticket: [HFEYP-221](https://dfedigital.atlassian.net/browse/HFEYP-221)
## Tech review

Made changes to content page model so first and last pages don't connect to each other. The first content page should not have a previous page and only a 'next page' link should be visible. The final content page should not have a next page and only a 'previous page' link should be visible.

The change will only come into effect when a page is created or a position attribute changes (or by manually calling ```ContentPage#reorder``` method)

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true

## Product review

### How can someone see it in review app?
1. Go to [first content page in review app](https://eyfs-review-pr-597.london.cloudapps.digital/get-help-to-improve-your-practice)
2. Verify that there is no "previous page" link visible
3. Go to [last content page in review app ](https://eyfs-review-pr-597.london.cloudapps.digital/communication-and-language/listening-and-understanding)
4. Verify that there is no "next page" link visible