### PR TITLE
Add intro to content page and fix ToC bug

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -41,8 +41,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ebrett
-          password: ${{ secrets.GHCR_PERSONAL_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push docker image from builder target
         uses: docker/build-push-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,10 @@
 /public/packs
 /public/packs-test
 /node_modules
+
 /vendor/cache
+/vendor/bundle
+
 yarn-debug.log*
 .yarn-integrity
 
@@ -33,6 +36,7 @@ yarn-debug.log*
 .env.development
 *.log
 /.idea
+/.tool-versions
 .DS_Store
 /coverage
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ and environment variable called AUTH_ON_EVERYTHING.
 The ContentController will then use the devise accounts to check the basic auth, but it does
 not log users in.
 
+Creating an admin user:
+
+```
+User.create!(
+  first_name: 'First',
+  last_name: 'Last',
+  email: 'first.last@digital.education.gov.uk',
+  password: 'P4ssW0rd!!',
+  password_confirmation: 'P4ssW0rd!!',
+  role: 'admin',
+)
+```
 
 ### If there are issues with postgres password authentication failure:
 

--- a/app/controllers/admin/content_page_versions_controller.rb
+++ b/app/controllers/admin/content_page_versions_controller.rb
@@ -36,6 +36,7 @@ module Admin
 
     def preview_of_draft
       @page = ContentPage.new(title: @content_page_version.title,
+                              intro: @content_page_version.intro,
                               markdown: @content_page_version.markdown,
                               content_list: @content_page_version.content_list,
                               position: 22,
@@ -50,6 +51,7 @@ module Admin
       @page = @content_page_version.content_page
       @page.update!(
         markdown: @content_page_version.markdown,
+        intro: @content_page_version.intro,
         content_list: @content_page_version.content_list,
         is_published: true,
         author: current_user.name,
@@ -72,7 +74,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def content_page_version_params
-      params.require(:content_page_version).permit(:title, :markdown, :content_list, :author, :description)
+      params.require(:content_page_version).permit(:title, :intro, :markdown, :content_list, :author, :description)
     end
   end
 end

--- a/app/controllers/admin/content_pages_controller.rb
+++ b/app/controllers/admin/content_pages_controller.rb
@@ -67,6 +67,7 @@ module Admin
 
       if @content_page.valid?
         ContentPageVersion.create!(title: @content_page.title,
+                                   intro: content_page_params[:intro],
                                    markdown: content_page_params[:markdown],
                                    content_list: content_page_params[:content_list],
                                    author: current_user.name,
@@ -107,6 +108,7 @@ module Admin
       @content_page.update!(is_published: false)
       ContentPageVersion.create!(title: @content_page.title,
                                  markdown: @content_page.markdown,
+                                 intro: @content_page.intro,
                                  content_list: @content_page.content_list,
                                  author: current_user.name,
                                  content_page: @content_page,
@@ -124,7 +126,7 @@ module Admin
 
     # Only allow a list of trusted parameters through.
     def content_page_params
-      params.require(:content_page).permit(:title, :markdown, :content_list, :parent_id, :position, :description)
+      params.require(:content_page).permit(:title, :intro, :markdown, :content_list, :parent_id, :position, :description)
     end
   end
 end

--- a/app/views/admin/content_page_versions/_form.html.erb
+++ b/app/views/admin/content_page_versions/_form.html.erb
@@ -8,6 +8,8 @@
 
           <%= form.govuk_text_field :title, label: {text: "Heading"}, :class => 'govuk-input govuk-!-width-three-quarters'%>
 
+        <%= form.govuk_text_area :intro, label: { text: "Introduction" } %>
+
           <!-- This text_area is not rendered with gov_text_field because it needs to
                set its own id, and the GOVUKDesignSystemFormBuilder hijacks it -->
           <div class="govuk-form-group gem-c-govspeak">
@@ -43,6 +45,9 @@
 
     <div class="govuk-grid-column-one-half">
         <p class="govuk-heading-m">Preview</p>
+        <div class='gem-c-govspeak'>
+          <%= translate_markdown(@content_page_version.intro) %>
+        </div>
         <div id='content-list-render' class='gem-c-govspeak'>
           <%= translate_markdown(@content_page_version.content_list) %>
         </div>

--- a/app/views/admin/content_page_versions/preview_of_draft.erb
+++ b/app/views/admin/content_page_versions/preview_of_draft.erb
@@ -5,6 +5,8 @@
 <h1 class="govuk-heading-l">
   <%= @content_page_version.title %>
 </h1>
+<%= translate_markdown(@content_page_version.intro) %>
+
 <% if @content_page_version.content_list %>
   <p id="contents-list-heading" class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
   <%= translate_markdown(@content_page_version.content_list) %>

--- a/app/views/admin/content_page_versions/preview_of_draft.erb
+++ b/app/views/admin/content_page_versions/preview_of_draft.erb
@@ -5,6 +5,7 @@
 <h1 class="govuk-heading-l">
   <%= @content_page_version.title %>
 </h1>
+
 <%= translate_markdown(@content_page_version.intro) %>
 
 <% if @content_page_version.content_list %>

--- a/app/views/admin/content_pages/_form.html.erb
+++ b/app/views/admin/content_pages/_form.html.erb
@@ -7,6 +7,8 @@
 
         <%= form.govuk_text_field :title, label: {text: "Heading"}, :class => 'govuk-input govuk-!-width-three-quarters', :disabled => (@content_page.title && !@content_page.parent_id)%>
 
+        <%= form.govuk_text_area :intro, label: { text: "Introduction" } %>
+
         <!-- This text_area is not rendered with gov_text_field because it needs to
              set its own id, and the GOVUKDesignSystemFormBuilder hijacks it -->
         <% markdown_class = 'govuk-form-group--error' if @content_page&.errors[:markdown].present? %> 
@@ -43,6 +45,9 @@
 
     <div class="govuk-grid-column-one-half">
         <p class="govuk-heading-m">Preview</p>
+        <div id='content-list-render' class='gem-c-govspeak'>
+          <%= translate_markdown(content_page.intro) %>
+        </div>
         <div id='content-list-render' class='gem-c-govspeak'>
           <%= translate_markdown(content_page.content_list) %>
         </div>

--- a/app/views/admin/content_pages/_form.html.erb
+++ b/app/views/admin/content_pages/_form.html.erb
@@ -45,7 +45,7 @@
 
     <div class="govuk-grid-column-one-half">
         <p class="govuk-heading-m">Preview</p>
-        <div id='content-list-render' class='gem-c-govspeak'>
+        <div class='gem-c-govspeak'>
           <%= translate_markdown(content_page.intro) %>
         </div>
         <div id='content-list-render' class='gem-c-govspeak'>

--- a/app/views/admin/content_pages/preview_of_live.erb
+++ b/app/views/admin/content_pages/preview_of_live.erb
@@ -5,6 +5,9 @@
 <h1 class="govuk-heading-l">
   <%= @content_page.title %>
 </h1>
+
+<%= translate_markdown(@content_page.intro) %>
+
 <% if @content_page.content_list %>
   <p id="contents-list-heading" class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
   <%= translate_markdown(@content_page.content_list) %>

--- a/app/views/admin/content_pages/preview_of_live.erb
+++ b/app/views/admin/content_pages/preview_of_live.erb
@@ -8,7 +8,7 @@
 
 <%= translate_markdown(@content_page.intro) %>
 
-<% if @content_page.content_list %>
+<% unless @content_page.content_list.blank? %>
   <p id="contents-list-heading" class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
   <%= translate_markdown(@content_page.content_list) %>
 <% end %>

--- a/app/views/admin/content_pages/show.html.erb
+++ b/app/views/admin/content_pages/show.html.erb
@@ -3,6 +3,8 @@
   <%= @content_page.title %>
 </p>
 
+<%= translate_markdown(@content_page.intro) %>
+
 <p>
   <strong>Content (Govspeak):</strong>
   <%= @content_page.markdown %>

--- a/app/views/content/show.html.erb
+++ b/app/views/content/show.html.erb
@@ -1,16 +1,24 @@
 <% if @page.parent %>
   <span class="govuk-caption-l"><%= @page.parent.title %></span>
 <% end %>
+
 <h1 class="govuk-heading-l">
   <%= @page.title %>
 </h1>
-<% if @page.content_list %>
-  <p id="contents-list-heading" class="govuk-body govuk-!-margin-bottom-1"> Contents </p>
+
+<%= translate_markdown(@page.intro) %>
+
+<% unless @page.content_list.blank? %>
+  <p id="contents-list-heading" class="govuk-body govuk-!-margin-bottom-1">
+    Contents
+  </p>
   <%= translate_markdown(@page.content_list) %>
 <% end %>
+
 <% if @page.content_list %>
   <%= print_button("govuk-!-margin-top-7") %>
 <% end %>
+
 <div class="govuk-!-margin-top-4">
   <%= translate_markdown(@page.markdown) %>
 </div>

--- a/db/migrate/20220812093437_add_intro_to_content_pages.rb
+++ b/db/migrate/20220812093437_add_intro_to_content_pages.rb
@@ -1,0 +1,5 @@
+class AddIntroToContentPages < ActiveRecord::Migration[6.1]
+  def change
+    add_column :content_pages, :intro, :string
+  end
+end

--- a/db/migrate/20220817134018_add_intro_to_content_page_versions.rb
+++ b/db/migrate/20220817134018_add_intro_to_content_page_versions.rb
@@ -1,0 +1,5 @@
+class AddIntroToContentPageVersions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :content_page_versions, :intro, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_03_120522) do
+ActiveRecord::Schema.define(version: 2022_08_12_093437) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,6 +130,7 @@ ActiveRecord::Schema.define(version: 2022_02_03_120522) do
     t.string "author"
     t.string "description"
     t.string "content_list"
+    t.string "intro"
     t.index ["position", "parent_id"], name: "index_content_pages_on_position_and_parent_id", unique: true
     t.index ["title"], name: "index_content_pages_on_title", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_12_093437) do
+ActiveRecord::Schema.define(version: 2022_08_17_134018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 2022_08_12_093437) do
     t.string "author"
     t.string "description"
     t.string "content_list"
+    t.string "intro"
     t.index ["content_page_id"], name: "index_content_page_versions_on_content_page_id"
   end
 

--- a/db/seeds/content_pages/communication_and_language.yml
+++ b/db/seeds/content_pages/communication_and_language.yml
@@ -34,6 +34,8 @@ interactions:
   parent: communication-and-language
   position: 1
   is_published: true
+  intro: |
+    Learn more about **interactions** as part of the early years foundation stage (EYFS) including advice from experts and suggested activities.
   markdown: |
     ## Why interactions are important
 

--- a/spec/factories/content_pages.rb
+++ b/spec/factories/content_pages.rb
@@ -9,6 +9,7 @@ end
 FactoryBot.define do
   factory :content_page do
     title { sentence_without_puncutation }
+    intro { Faker::Lorem.paragraph }
     content_list { Faker::Lorem.paragraph }
     markdown { "# Fake title - #{Faker::Lorem.word}" }
     parent_id { nil }

--- a/spec/features/content_pages_spec.rb
+++ b/spec/features/content_pages_spec.rb
@@ -33,6 +33,13 @@ RSpec.feature "View pages", type: :feature do
     page.find_field("content_page[title]", disabled: false)
   end
 
+  scenario "Navigate to a child page and see the intro can be edited" do
+    sign_in FactoryBot.create(:user)
+    visit "/admin/pages/#{child_page.id}/edit"
+
+    page.find_field("content_page[intro]", disabled: false)
+  end
+
   scenario "The CMS edit page should not have any accessibility errors" do
     sign_in FactoryBot.create(:user)
     visit "/admin/pages/#{parent_page.id}/edit"
@@ -75,6 +82,7 @@ RSpec.feature "View pages", type: :feature do
       visit "/admin/pages/new?parent_id=#{parent_page.id}"
 
       page.find_field("content_page[title]").set(attributes[:title])
+      page.find_field("content_page[intro]").set(attributes[:intro])
       page.find_field("content_page[content_list]").set(attributes[:content_list])
       page.find_field("content_page[markdown]").set(attributes[:markdown])
       page.find_field("content_page[position]").set(rand(10_000))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,6 @@ require "capybara/rspec"
 require "axe-rspec"
 require "webdrivers/chromedriver"
 
-# Pinned version of chromedriver as newer version was causing an error:
-# "unknown error: Cannot construct KeyEvent from non-typeable key"
-# To be removed when the error is fixed
-Webdrivers::Chromedriver.required_version = "97.0.4692.71"
-
 SimpleCov.start
 
 # This configuration seems to work well in CI environments:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ SimpleCov.start
 # This configuration seems to work well in CI environments:
 Capybara.register_driver :chrome_headless do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome
-  capabilities['goog:chromeOptions'] = {
+  capabilities["goog:chromeOptions"] = {
     args: %w[
       headless
       no-sandbox

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,14 +13,18 @@ SimpleCov.start
 
 # This configuration seems to work well in CI environments:
 Capybara.register_driver :chrome_headless do |app|
-  options = ::Selenium::WebDriver::Chrome::Options.new
-  options.add_argument("--headless")
-  options.add_argument("--no-sandbox")
-  options.add_argument("--disable-dev-shm-usage")
-  options.add_argument("--window-size=1400,1400")
-  options.add_argument("--disable-cache")
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome
+  capabilities['goog:chromeOptions'] = {
+    args: %w[
+      headless
+      no-sandbox
+      disable-dev-shm-usage
+      window-size=1400,1400
+      disable-cache
+    ],
+  }
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: capabilities)
 end
 
 Capybara.javascript_driver = :chrome_headless


### PR DESCRIPTION
## Ticket and context

Ticket: [HFEYP-353](https://dfedigital.atlassian.net/browse/ER-353)
<img width="1108" alt="Screenshot 2022-08-12 at 10 55 54" src="https://user-images.githubusercontent.com/3261/184331108-2bb4c6cb-084b-4d20-a198-4a0edc9c0ec4.png">

- add intro markdown field to content_page and render after the title
- only render TOC if not blank

## Tech review

### Is there anything that the code reviewer should know?

### Code quality checks
- [ ] All commit messages are meaningful and true

## Product review

### How can someone see it in review app?
1. Click the link to review app (posted by a `github-actions` bot below)
2. Follow the steps from the ticket.