### PR TITLE
Use new naming scheme for release candidates

### DIFF
--- a/.github/workflows/azure-deploy-stage.yml
+++ b/.github/workflows/azure-deploy-stage.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Check tag format
         run: |
-          echo ${{ inputs.candidate }} | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
+          echo ${{ inputs.candidate }} | grep -E '^rc[0-9]+\.[0-9]+\.[0-9]+$'
 
       # Tag the branch with the release candidate version
       - name: Tag candidate


### PR DESCRIPTION
[ER-861] Previously we only used 'v*.*.*` for versions.  Bring over the use if 'rc*.*.*' for release candidates for staging, from CDT.