### PR TITLE
ER-1069 Fix Card element behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ uml/*.*
 !uml/*.puml
 
 nscacert.pem
+
+# YARD documentation files
+*.yardoc
+

--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -1,7 +1,8 @@
 .hf-card {
   &-container {
     background-color: govuk-colour('light-grey');
-    border-bottom: 3px solid govuk-organisation-colour('department-for-education', false);
+    border-bottom: 3px solid
+      govuk-organisation-colour('department-for-education', false);
   }
 
   a {
@@ -11,15 +12,21 @@
       color: $govuk-text-colour;
     }
 
-    .hf-card-details h3 {
+    .hf-card-details h2,
+    h3 {
       color: $light-blue-link;
     }
 
     &:hover .hf-card-container {
-      background-color: govuk-organisation-colour('department-for-education', false);
+      background-color: govuk-organisation-colour(
+        'department-for-education',
+        false
+      );
 
-      .hf-card-details p, h3 {
-          color: govuk-colour('white');
+      .hf-card-details p,
+      .hf-card-details h2,
+      .hf-card-details h3 {
+        color: govuk-colour('white');
       }
     }
   }

--- a/app/views/pages/_card.html.slim
+++ b/app/views/pages/_card.html.slim
@@ -3,9 +3,12 @@
     a href=card.path
       .hf-card-container
         = card_thumbnail(card)
-
         .hf-card-details
-          h3.govuk-heading-m
-            = card.title
+          - if card.tier1?
+            h3.govuk-heading-m
+              = card.title
+          - else
+            h2.govuk-heading-m
+              = card.title
           p.govuk-body
             = card.meta_description || card.hero_description

--- a/spec/system/cards_spec.rb
+++ b/spec/system/cards_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe 'Card heading levels based on tier' do
+  describe 'Homepage renders h3 for tier1 card' do
+    before do
+      visit '/homepage'
+    end
+
+    it 'renders h3 for tier1 card' do
+      all('.hf-card-details').each do |card|
+        within card do
+          expect(page).to have_css('h3.govuk-heading-m', text: 'Card Title')
+          expect(page).not_to have_css('h2.govuk-heading-m')
+        end
+      end
+    end
+  end
+
+  describe 'Section page renders h2 for tier2 card' do
+    before do
+      visit '/section-page'
+    end
+
+    it 'renders h2 for tier2 card' do
+      all('.hf-card-details').each do |card|
+        within card do
+          expect(page).to have_css('h2.govuk-heading-m', text: 'Card Title')
+          expect(page).not_to have_css('h3.govuk-heading-m')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Changed the behaviour of the card element so that its title becomes a h3 in stead of a h2 if the page tier is not 1.

<img width="1709" alt="Screenshot 2024-08-06 at 15 23 44" src="https://github.com/user-attachments/assets/70ebb867-bbbe-4d1c-8c67-9d756db37184">

<img width="1640" alt="Screenshot 2024-08-06 at 15 24 20" src="https://github.com/user-attachments/assets/14f04069-f68d-4026-a813-3d39bc82609c">

As specified in: [https://dfedigital.atlassian.net/browse/ER-1069](url)