### PR TITLE
Make environment available on rails config bject and use to instantia…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on: [push]
 
 env:
   RAILS_ENV: test
+  ENVIRONMENT: test
 
 jobs:
   tests:

--- a/config/application.rb
+++ b/config/application.rb
@@ -63,8 +63,8 @@ module GovukRailsBoilerplate
     #
 
     # @return [Boolean]
-    config.environment = ENV['ENVIRONMENT']
-    
+    config.environment = ENV.fetch('ENVIRONMENT')
+
     def live?
       config.environment.eql?('production')
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -63,18 +63,20 @@ module GovukRailsBoilerplate
     #
 
     # @return [Boolean]
+    config.environment = ENV['ENVIRONMENT']
+    
     def live?
-      ENV['ENVIRONMENT'].eql?('production')
+      config.environment.eql?('production')
     end
 
     # @return [Boolean]
     def staging?
-      ENV['ENVIRONMENT'].eql?('staging')
+      config.environment.eql?('staging')
     end
 
     # @return [Boolean]
     def dev?
-      ENV['ENVIRONMENT'].eql?('development')
+      config.environment.eql?('development')
     end
 
     # @return [Boolean]

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,7 +1,6 @@
 Sentry.init do |config|
   config.dsn = Rails.application.config.sentry_dsn
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
-  config.enabled_environments = %w[production]
   config.environment = Rails.application.config.environment
   # Set tracesSampleRate to 1.0 to capture 100%
   # of transactions for performance monitoring.

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,7 +2,7 @@ Sentry.init do |config|
   config.dsn = Rails.application.config.sentry_dsn
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
   config.enabled_environments = %w[production]
-
+  config.environment = Rails.application.config.environment
   # Set tracesSampleRate to 1.0 to capture 100%
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production


### PR DESCRIPTION
…te Sentry with an environment


What happens if the env var isn't there

```
config.environment = ENV['ENVIRONMENT']
```
??

Why, in the config do we do this in a number of ways? Which is best for this addition?
eg

```
ENV.fetch('CONTENTFUL_SPACE', credentials.dig(:contentful, :space))
ENV.fetch('FEEDBACK_URL', '#FEEDBACK_env_var_missing')
ENV['ENVIRONMENT']  # ENV['ENVIRONMENT'].eql?('development')
```