### PR TITLE
terraform-azure/terraform-azure-database/main.tf

### DIFF
--- a/terraform-azure/terraform-azure-database/main.tf
+++ b/terraform-azure/terraform-azure-database/main.tf
@@ -38,7 +38,7 @@ resource "azurerm_postgresql_flexible_server" "psqlfs" {
 resource "azurerm_postgresql_flexible_server_configuration" "psqlfs_config" {
   name      = "azure.extensions"
   server_id = azurerm_postgresql_flexible_server.psqlfs.id
-  value     = "CITEXT,FUZZYSTRMATCH,PGCRYPTO,PLPGSQL,UUID-OSSP"
+  value     = "CITEXT,FUZZYSTRMATCH,PGCRYPTO,UUID-OSSP"
 }
 
 # Create Database


### PR DESCRIPTION
* Remove PLPGSQL value from server options for Azure flexible db This value is not required as PGPLSQL is active by default as an extension on this db and is therefore not a valid option