### PR TITLE
Add new refresh command for terraform

### DIFF
--- a/.github/workflows/tf-azure-deploy.yml
+++ b/.github/workflows/tf-azure-deploy.yml
@@ -12,6 +12,11 @@ on:
           - development
           - staging
           - production
+      refresh:
+        description: 'Use the refresh-only flag on this plan'
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -82,7 +87,13 @@ jobs:
         id: tf-plan
         run: |
           export exitcode=0
-          terraform plan -detailed-exitcode -no-color -out tfplan || export exitcode=$?
+
+
+          if ${{ inputs.refresh }}; then
+            terraform plan -detailed-exitcode -no-color -refresh-only -out tfplan || export exitcode=$?
+          else
+            terraform plan -detailed-exitcode -no-color -out tfplan || export exitcode=$?
+          fi
           
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
           


### PR DESCRIPTION
Add boolean flag to github action for planning terraform which accepts argument allowing us to trigger a refresh plan

https://developer.hashicorp.com/terraform/cli/commands/refresh

Refresh plans update the terraform state file without updating infrastructure.