### PR TITLE
Expose ENV env var in dockerfile on non-preview runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN echo "root:Docker!" | chpasswd && cd /etc/ssh/ && ssh-keygen -A
 
 ENV APP_HOME /srv
 ENV RAILS_ENV ${RAILS_ENV:-production}
+ENV ENVIRONMENT ${ENVIRONMENT:-production}
 ENV AUTHORIZED_HOSTS 127.0.0.1
 ENV IGNORE_SECRETS_FOR_BUILD=1
 


### PR DESCRIPTION
Fixes:
```

#42 [app 21/23] RUN SECRET_KEY_BASE=x bundle exec rails assets:precompile
#42 2.388 bin/rails aborted!
#42 2.389 KeyError: key not found: "ENVIRONMENT" (KeyError)
```

https://github.com/DFE-Digital/early-years-foundation-reform/actions/runs/15190058128/job/42723385964
