### PR TITLE
EYP-264 - Adds Redis tf

### DIFF
--- a/adr/0013-azure-managed-redis-via-azapi-temporarily.md
+++ b/adr/0013-azure-managed-redis-via-azapi-temporarily.md
@@ -1,0 +1,66 @@
+# Use AzAPI for Azure Managed Redis temporarily
+
+* Status: accepted
+
+## Context and Problem Statement
+
+We are adding Azure Managed Redis for caching. A portfolio example uses
+`azurerm_managed_redis`, but this repository currently pins `azurerm` to
+`3.71.0` in `terraform-azure/terraform.tf`.
+
+At this pinned provider version, `azurerm_managed_redis` is not available.
+Using only native `azurerm` resources at this version would force older Redis
+Enterprise resource patterns and does not align with the managed Redis model we
+want to adopt.
+
+## Decision Drivers
+
+* Deliver Azure Managed Redis safely.
+* Avoid a broad provider-major upgrade while introducing new infrastructure.
+* Keep implementation aligned with current provider constraints.
+* Leave a clear migration path to native `azurerm_managed_redis`.
+
+## Considered Options
+
+* **Upgrade `azurerm` to 4.x now and use `azurerm_managed_redis`.**
+  Not chosen for this PR due to medium upgrade risk and broader infra impact.
+* **Use `azurerm_redis_enterprise_*` resources on `3.71.0`.**
+  Not chosen as the SKU and model differ from Azure Managed Redis requirements.
+* **Use AzAPI now for Managed Redis, then migrate later.**
+  Chosen.
+
+## Decision Outcome
+
+For this PR, we implement Azure Managed Redis using:
+
+* `azapi_resource` for `Microsoft.Cache/redisEnterprise` and child database.
+* `azurerm_private_endpoint` and private DNS scaffolding for private access.
+* `azurerm` data source usage where possible for key retrieval.
+* A compatibility-first toggle for access-key authentication (enabled by default).
+
+This keeps delivery moving without taking on a provider-major upgrade in the
+same change set.
+
+## Consequences
+
+### Positive
+
+* Enables Azure Managed Redis now on the existing provider baseline.
+* Reduces blast radius of this PR by isolating provider-upgrade risk.
+* Keeps private networking and app wiring moving forward.
+
+### Negative
+
+* We rely on `azapi_resource` with limited schema-time validation.
+* Configuration is split across providers (`azurerm` + `azapi`).
+* Access-key authentication remains enabled by default for current app compatibility.
+* Migration work remains to move to native `azurerm_managed_redis`.
+
+## Follow-up / Migration Trigger
+
+Create a follow-up infra PR to upgrade `azurerm` to a compatible 4.x version and
+migrate Redis resources to `azurerm_managed_redis` when:
+
+* Terraform plan/apply for existing modules is validated against 4.x.
+* Required provider-breaking changes are addressed and reviewed.
+* A migration plan for Redis resource/state transition is approved.

--- a/adr/ADR.md
+++ b/adr/ADR.md
@@ -17,6 +17,7 @@ This log lists the architectural decisions for EYFS Recovery
 * [ADR-0010](0010-contentful.md) - Use Contentful CMS for content storage
 * [ADR-0011](0011-sentry-monitoring.md) - Monitoring with Sentry
 * [ADR-0012](0012-asset-pipeline-static-paths.md) - Serve govuk-frontend assets statically and disable runtime asset compilation
+* [ADR-0013](0013-azure-managed-redis-via-azapi-temporarily.md) - Use AzAPI for Azure Managed Redis temporarily
 
 <!-- adrlogstop -->
 

--- a/terraform-azure/local.tf
+++ b/terraform-azure/local.tf
@@ -26,6 +26,10 @@ locals {
     "RAILS_MASTER_KEY"                    = var.webapp_config_rails_master_key
     "RAILS_MAX_THREADS"                   = var.webapp_config_rails_max_threads
     "RAILS_SERVE_STATIC_FILES"            = var.webapp_config_rails_serve_static_files
+    "REDIS_HOST"                          = "${azapi_resource.redis.name}.${var.azure_region}.redisenterprise.cache.azure.net"
+    "REDIS_PASSWORD"                      = var.redis_access_keys_authentication_enabled ? data.azurerm_redis_enterprise_database.redis_default.primary_access_key : null
+    "REDIS_PORT"                          = "10000"
+    "REDIS_USERNAME"                      = var.redis_access_keys_authentication_enabled ? "default" : null
     "SENTRY_DSN"                          = var.webapp_config_sentry_dsn
     "TRACKING_ID"                         = var.tracking_id
     "CLARITY_TRACKING_ID"                 = var.clarity_tracking_id
@@ -48,6 +52,10 @@ locals {
     "RAILS_MASTER_KEY"                    = var.webapp_config_rails_master_key
     "RAILS_MAX_THREADS"                   = var.webapp_config_rails_max_threads
     "RAILS_SERVE_STATIC_FILES"            = var.webapp_config_rails_serve_static_files
+    "REDIS_HOST"                          = "${azapi_resource.redis.name}.${var.azure_region}.redisenterprise.cache.azure.net"
+    "REDIS_PASSWORD"                      = var.redis_access_keys_authentication_enabled ? data.azurerm_redis_enterprise_database.redis_default.primary_access_key : null
+    "REDIS_PORT"                          = "10000"
+    "REDIS_USERNAME"                      = var.redis_access_keys_authentication_enabled ? "default" : null
     "SENTRY_DSN"                          = var.webapp_config_sentry_dsn
     "TRACKING_ID"                         = var.tracking_id
     "CLARITY_TRACKING_ID"                 = var.clarity_tracking_id

--- a/terraform-azure/local.tf
+++ b/terraform-azure/local.tf
@@ -29,6 +29,7 @@ locals {
     "REDIS_HOST"                          = "${azapi_resource.redis.name}.${var.azure_region}.redisenterprise.cache.azure.net"
     "REDIS_PASSWORD"                      = var.redis_access_keys_authentication_enabled ? data.azurerm_redis_enterprise_database.redis_default.primary_access_key : null
     "REDIS_PORT"                          = "10000"
+    "REDIS_URL"                           = var.redis_access_keys_authentication_enabled ? "rediss://default:${urlencode(data.azurerm_redis_enterprise_database.redis_default.primary_access_key)}@${azapi_resource.redis.name}.${var.azure_region}.redisenterprise.cache.azure.net:10000/0" : "rediss://${azapi_resource.redis.name}.${var.azure_region}.redisenterprise.cache.azure.net:10000/0"
     "REDIS_USERNAME"                      = var.redis_access_keys_authentication_enabled ? "default" : null
     "SENTRY_DSN"                          = var.webapp_config_sentry_dsn
     "TRACKING_ID"                         = var.tracking_id
@@ -55,6 +56,7 @@ locals {
     "REDIS_HOST"                          = "${azapi_resource.redis.name}.${var.azure_region}.redisenterprise.cache.azure.net"
     "REDIS_PASSWORD"                      = var.redis_access_keys_authentication_enabled ? data.azurerm_redis_enterprise_database.redis_default.primary_access_key : null
     "REDIS_PORT"                          = "10000"
+    "REDIS_URL"                           = var.redis_access_keys_authentication_enabled ? "rediss://default:${urlencode(data.azurerm_redis_enterprise_database.redis_default.primary_access_key)}@${azapi_resource.redis.name}.${var.azure_region}.redisenterprise.cache.azure.net:10000/0" : "rediss://${azapi_resource.redis.name}.${var.azure_region}.redisenterprise.cache.azure.net:10000/0"
     "REDIS_USERNAME"                      = var.redis_access_keys_authentication_enabled ? "default" : null
     "SENTRY_DSN"                          = var.webapp_config_sentry_dsn
     "TRACKING_ID"                         = var.tracking_id

--- a/terraform-azure/redis.tf
+++ b/terraform-azure/redis.tf
@@ -7,8 +7,8 @@ resource "azapi_resource" "redis" {
 
   body = {
     properties = {
-      highAvailability  = "Disabled"
-      minimumTlsVersion = "1.2"
+      highAvailability    = "Disabled"
+      minimumTlsVersion   = "1.2"
       publicNetworkAccess = "Disabled"
     }
     sku = {
@@ -26,12 +26,45 @@ resource "azapi_resource" "redis_default_database" {
 
   body = {
     properties = {
-      accessKeysAuthentication = "Enabled"
+      accessKeysAuthentication = var.redis_access_keys_authentication_enabled ? "Enabled" : "Disabled"
       clientProtocol           = "Encrypted"
       clusteringPolicy         = "EnterpriseCluster"
       evictionPolicy           = "AllKeysLRU"
+      port                     = 10000
     }
   }
 
   schema_validation_enabled = false
+}
+
+data "azurerm_redis_enterprise_database" "redis_default" {
+  name                = "default"
+  cluster_id          = azapi_resource.redis.id
+  resource_group_name = azurerm_resource_group.rg.name
+
+  depends_on = [azapi_resource.redis_default_database]
+}
+
+resource "azurerm_private_endpoint" "redis" {
+  name                = "${var.resource_name_prefix}-redis-pe"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = var.azure_region
+  subnet_id           = module.network.redis_private_endpoint_subnet_id
+  tags                = local.common_tags
+
+  private_service_connection {
+    name                           = "${var.resource_name_prefix}-redis-psc"
+    private_connection_resource_id = azapi_resource.redis.id
+    is_manual_connection           = false
+    subresource_names              = ["redisEnterprise"]
+  }
+
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [module.network.redis_private_dns_zone_id]
+  }
+
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }

--- a/terraform-azure/redis.tf
+++ b/terraform-azure/redis.tf
@@ -1,0 +1,37 @@
+resource "azapi_resource" "redis" {
+  type      = "Microsoft.Cache/redisEnterprise@2025-04-01"
+  name      = "${var.resource_name_prefix}-redis"
+  location  = var.azure_region
+  parent_id = azurerm_resource_group.rg.id
+  tags      = local.common_tags
+
+  body = {
+    properties = {
+      highAvailability  = "Disabled"
+      minimumTlsVersion = "1.2"
+      publicNetworkAccess = "Disabled"
+    }
+    sku = {
+      name = "Balanced_B0"
+    }
+  }
+
+  schema_validation_enabled = false
+}
+
+resource "azapi_resource" "redis_default_database" {
+  type      = "Microsoft.Cache/redisEnterprise/databases@2025-04-01"
+  name      = "default"
+  parent_id = azapi_resource.redis.id
+
+  body = {
+    properties = {
+      accessKeysAuthentication = "Enabled"
+      clientProtocol           = "Encrypted"
+      clusteringPolicy         = "EnterpriseCluster"
+      evictionPolicy           = "AllKeysLRU"
+    }
+  }
+
+  schema_validation_enabled = false
+}

--- a/terraform-azure/terraform-azure-network/outputs.tf
+++ b/terraform-azure/terraform-azure-network/outputs.tf
@@ -13,6 +13,16 @@ output "webapp_subnet_id" {
   value       = azurerm_subnet.webapp_snet.id
 }
 
+output "redis_private_endpoint_subnet_id" {
+  description = "ID of the Subnet for Redis Private Endpoints"
+  value       = azurerm_subnet.redis_pe_snet.id
+}
+
+output "redis_private_dns_zone_id" {
+  description = "ID of the Private DNS Zone for Azure Managed Redis"
+  value       = azurerm_private_dns_zone.redis.id
+}
+
 output "agw_subnet_id" {
   description = "ID of the Subnet for the App Gateway"
   value       = var.environment != "development" ? azurerm_subnet.agw_snet[0].id : null

--- a/terraform-azure/terraform-azure-network/vnet.tf
+++ b/terraform-azure/terraform-azure-network/vnet.tf
@@ -32,10 +32,10 @@ resource "azurerm_subnet" "webapp_snet" {
 
 # Create Subnet for Redis Private Endpoint
 resource "azurerm_subnet" "redis_pe_snet" {
-  name                 = "${var.resource_name_prefix}-redis-pe-snet"
-  virtual_network_name = azurerm_virtual_network.vnet.name
-  resource_group_name  = var.resource_group
-  address_prefixes     = ["172.1.2.0/27"]
+  name                                      = "${var.resource_name_prefix}-redis-pe-snet"
+  virtual_network_name                      = azurerm_virtual_network.vnet.name
+  resource_group_name                       = var.resource_group
+  address_prefixes                          = ["172.1.2.0/27"]
   private_endpoint_network_policies_enabled = false
 
   #checkov:skip=CKV2_AZURE_31:NSG not required

--- a/terraform-azure/terraform-azure-network/vnet.tf
+++ b/terraform-azure/terraform-azure-network/vnet.tf
@@ -30,6 +30,17 @@ resource "azurerm_subnet" "webapp_snet" {
   #checkov:skip=CKV2_AZURE_31:NSG not required
 }
 
+# Create Subnet for Redis Private Endpoint
+resource "azurerm_subnet" "redis_pe_snet" {
+  name                 = "${var.resource_name_prefix}-redis-pe-snet"
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = var.resource_group
+  address_prefixes     = ["172.1.2.0/27"]
+  private_endpoint_network_policies_enabled = false
+
+  #checkov:skip=CKV2_AZURE_31:NSG not required
+}
+
 # Create Subnet for App Gateway
 resource "azurerm_subnet" "agw_snet" {
   # Subnet only deployed to the Test and Production subscription
@@ -42,4 +53,17 @@ resource "azurerm_subnet" "agw_snet" {
   service_endpoints    = ["Microsoft.Storage", "Microsoft.Web"]
 
   #checkov:skip=CKV2_AZURE_31:NSG not required
+}
+
+# Create Private DNS Zone for Azure Managed Redis
+resource "azurerm_private_dns_zone" "redis" {
+  name                = "privatelink.redisenterprise.cache.azure.net"
+  resource_group_name = var.resource_group
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
+  name                  = "${var.resource_name_prefix}-redis-pdz-vnet-link"
+  private_dns_zone_name = azurerm_private_dns_zone.redis.name
+  resource_group_name   = var.resource_group
+  virtual_network_id    = azurerm_virtual_network.vnet.id
 }

--- a/terraform-azure/terraform.tf
+++ b/terraform-azure/terraform.tf
@@ -6,7 +6,8 @@ terraform {
       version = "= 3.71.0"
     }
     azapi = {
-      source = "Azure/azapi"
+      source  = "Azure/azapi"
+      version = "= 2.10.0"
     }
   }
 

--- a/terraform-azure/terraform.tf
+++ b/terraform-azure/terraform.tf
@@ -5,6 +5,9 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "= 3.71.0"
     }
+    azapi = {
+      source = "Azure/azapi"
+    }
   }
 
   required_version = ">= 1.5.0"

--- a/terraform-azure/variables.tf
+++ b/terraform-azure/variables.tf
@@ -159,3 +159,9 @@ variable "webapp_config_sentry_dsn" {
 variable "webapp_config_web_concurrency" {
   type = string
 }
+
+variable "redis_access_keys_authentication_enabled" {
+  description = "Enable Redis access-key authentication for application compatibility"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Coauthored by @david-dfe

This PR introduces Azure Managed Redis for the service and wires in private networking and application settings to support cache usage.
Given the current AzureRM provider pin in this repository, native managed Redis resources are not yet viable for our chosen SKU model, so this implementation uses AzAPI as an interim approach and documents that decision in a new ADR.
The repo is currently pinned to AzureRM 3.71.0.
At this provider level, the desired Azure Managed Redis pattern is not fully supported with native AzureRM resources for our SKU path.
Upgrading AzureRM to 4.x in the same change would significantly increase PR scope and risk.
Therefore this PR uses AzAPI now, with a clear documented migration path to native AzureRM managed Redis later.


**Changes:** 

- Added Azure Managed Redis cluster and default database resources using AzAPI.
- Disabled public network access on the Redis cluster.
- Enforced TLS client protocol for the default Redis database.
- Added Redis private endpoint in the platform VNet.
- Added private DNS zone and VNet link for managed Redis private resolution.
- Added dedicated subnet for Redis private endpoints.
- Explicitly set private endpoint subnet policy behavior for deployment robustness.
- Added application settings for Redis host/port/username/password for both app and slot.
- Added a configuration toggle for access-key authentication:
- Compatibility-first default is enabled.
- App settings are conditional so key-auth can be disabled later without breaking Terraform wiring.
- Added ADR documenting the interim AzAPI decision and migration trigger.
- Updated ADR index to include the new decision record.
- New ADR added to document:
      1. Why AzAPI is used now.
      2. Trade-offs and risks.
      3. Conditions for migrating to native AzureRM managed Redis in a follow-up PR.
      4. Security and networking posture

- Redis public network access is disabled.
- Private endpoint is configured for Redis access from within the VNet.
- Private DNS integration is configured for endpoint name resolution.
- TLS-encrypted client protocol is configured.
- Access-key auth remains enabled by default for compatibility, but is now configurable.
- Validation and checks run
- Terraform formatting check passed.
- Terraform init (backend disabled) passed.
- Terraform validate passed.

**Risks**

- AzAPI schema validation remains disabled for Redis resources in this implementation, so some payload issues are caught later than with fully typed resources.
- Access-key auth is enabled by default today for application compatibility.
- Managed Redis is introduced with new network dependencies (private endpoint + DNS); runtime verification after deployment is required.

**Out of scope**

- AzureRM provider major upgrade to 4.x.
- Migration from AzAPI resources to native AzureRM managed Redis resources.
- Broader remediation of existing non-Redis infrastructure security findings.
- Current default is key auth enabled for compatibility. If we disable it later, REDIS_USERNAME/REDIS_PASSWORD become null, and app must use a different auth path (not currently implemented).

**Rollback plan**

- Revert this PR to remove Redis resources, private endpoint, DNS scaffolding, and app settings.
- Re-run Terraform plan/apply to return infrastructure to pre-change state.
- Follow-up actions
- Create a dedicated infra PR to upgrade AzureRM to a compatible 4.x range.
- Migrate Redis from AzAPI to native AzureRM managed Redis in that follow-up.
- Reassess and potentially disable key-auth once application auth strategy is confirmed.


Release checklist for this PR

 **Terraform and CI** 

- [ ] terraform fmt -check -recursive passes in [terraform-azure]
- [x]  terraform validate passes in [terraform-azure]
- [x]  PR CI “Terraform Format” and “Terraform Unit Tests” are green
- [x]  ADR is present and indexed
- [x] Infra configuration decisions
- [x]  Confirm redis_access_keys_authentication_enabled value for target env (default is true) in [variables.tf:170](
- [x]  Confirm this matches app auth expectations (key-based for now)
- [x]  Confirm private endpoint subnet policy remains explicit in [vnet.tf:39]

 **App settings injected by Terraform (verify after deploy)**

- [ ]  REDIS_HOST exists on app and slot
- [x]  REDIS_PORT = 10000
- [x]  REDIS_USERNAME and REDIS_PASSWORD present when key-auth enabled
- [x]  Settings present in both main app and slot (from [local.tf:14]

 **Network and connectivity**

- [x]  Redis public network access is disabled (from [redis.tf:12]
- [x]  Private endpoint created (from [redis.tf:48](
- [x]  Private DNS zone and VNet link created (from [vnet.tf:57]
- [ ]  App can resolve Redis private hostname from runtime context
- [x]  App can connect to Redis on port 10000 from its subnet

**Functional readiness** 

- [x]  Confirm whether app code is actually using Redis cache/session in production config
- [ ]  If not, create follow-up app PR to wire Rails cache/session to Redis before claiming caching is “live”

 **Post-deploy smoke test**

- [ ]  Basic cache write/read succeeds in target environment
- [ ]  No increase in app errors/timeouts after rollout
- [ ]  Slot swap/rollback plan is ready