### PR TITLE
Refactor error handling in PagesController 

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,18 +6,22 @@ class PagesController < ApplicationController
   layout 'hero'
 
   def index
-    render 'errors/not_found', layout: 'application' if page.nil?
+    render_not_found if page.nil?
   end
 
   def show
     if page.nil?
-      render 'errors/not_found', layout: 'application'
+      render_not_found
     else
       render page.to_partial_path
     end
   end
 
 private
+
+  def render_not_found
+    render 'errors/not_found', layout: 'application', status: :not_found, formats: [:html]
+  end
 
   def breadcrumbs
     page.breadcrumbs

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -4,15 +4,22 @@ RSpec.describe PagesController, type: :request do
   describe 'when an incorrect url is used' do
     it 'shows the page not found content' do
       get '/incorrect-url'
-      expect(response).to have_http_status(:success)
+      expect(response).to have_http_status(:not_found)
       expect(response.body).to include 'Page not found'
     end
   end
 
   describe 'when an incorrect url is used in an incorrect format' do
-    it 'returns an error page with a 406 (Not Acceptable) error code' do
+    it 'returns the page not found content with a 404' do
       get '/incorrect-url.css'
-      expect(response.body).to include 'UnknownFormat'
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include 'Page not found'
+    end
+
+    it 'returns the page not found content with a 404 for apple touch icon requests' do
+      get '/apple-touch-icon-152x152-precomposed.png'
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include 'Page not found'
     end
   end
 end


### PR DESCRIPTION
Refactor error handling in PagesController to use a dedicated render not_found method and update specs for accurate status codes